### PR TITLE
Communicator with Half Precision

### DIFF
--- a/distributed/cifar10-100/args.py
+++ b/distributed/cifar10-100/args.py
@@ -31,6 +31,9 @@ def get_args(monitor_path='tmp.monitor', max_iter=234300, model_save_path='tmp.m
     parser.add_argument("--val-iter", "-j", type=int, default=100)
     parser.add_argument("--weight-decay", "-w",
                         type=float, default=weight_decay)
+    parser.add_argument("--sync-weight-every-itr",
+                        type=int, default=100,
+                        help="Sync weights every specified iteration. NCCL uses the ring all reduce, so gradients in each device are not exactly same. When it is accumulated in the weights, the weight values in each device diverge.")
     parser.add_argument("--device-id", "-d", type=str, default='0',
                         help='Device ID the training run on. This is only valid if you specify `-c cudnn`.')
     parser.add_argument("--type-config", "-t", type=str, default='float',

--- a/distributed/cifar10-100/multi_device_multi_process_classification.py
+++ b/distributed/cifar10-100/multi_device_multi_process_classification.py
@@ -71,7 +71,7 @@ def train():
 
     # Create Communicator and Context
     extension_module = "cudnn"
-    ctx = get_extension_context(extension_module)
+    ctx = get_extension_context(extension_module, type_config=args.type_config)
     comm = C.MultiProcessDataParalellCommunicator(ctx)
     comm.init()
     n_devices = comm.size

--- a/distributed/cifar10-100/multi_device_multi_process_classification.py
+++ b/distributed/cifar10-100/multi_device_multi_process_classification.py
@@ -50,7 +50,8 @@ def train():
       * Execute forwardprop
       * Set parameter gradients zero
       * Execute backprop.
-      * Solver updates parameters by using gradients computed by backprop.
+      * AllReduce for gradients
+      * Solver updates parameters by using gradients computed by backprop and all reduce.
       * Compute training error
     """
     # Parse args
@@ -166,8 +167,8 @@ def train():
         loss_train.backward(clear_buffer=True)
 
         # AllReduce
-        params = [x.grad for x in nn.get_parameters().values()]
-        comm.all_reduce(params, division=False, inplace=False)
+        grads = [x.grad for x in nn.get_parameters().values()]
+        comm.all_reduce(grads, division=False, inplace=False)
 
         # Solvers update
         solver.update()

--- a/distributed/cifar10-100/multi_device_multi_process_classification.py
+++ b/distributed/cifar10-100/multi_device_multi_process_classification.py
@@ -172,6 +172,11 @@ def train():
         # Solvers update
         solver.update()
 
+        # Synchronize by averaging the weights over devices using allreduce
+        if (i+1) % args.sync_weight_every_itr == 0:
+            weights = [x.data for x in nn.get_parameters().values()]
+            comm.all_reduce(weights, division=True, inplace=True)
+
         # Linear Warmup
         if i <= warmup_iter:
             lr = base_lr + warmup_slope * i


### PR DESCRIPTION
Now, the communicator can take data with the half precision in the same way to do a single GPU training with the half precision like

```python
ctx = get_extension_context("cudnn", type_config="half")
```
