### PR TITLE
YOLO v2 inference with pretrained weights

### DIFF
--- a/object-detection/yolov2/.gitignore
+++ b/object-detection/yolov2/.gitignore
@@ -1,0 +1,7 @@
+coco.names
+imagenet.shortname.list
+*.weights
+*.h5
+*.nnp
+*.jpg
+

--- a/object-detection/yolov2/README.md
+++ b/object-detection/yolov2/README.md
@@ -1,0 +1,45 @@
+# YOLO v2 : Image object detection
+
+## Training
+
+TODO: Add training example.
+
+## Inference
+
+TODO: Add requirements.txt
+
+This example demonstrates YOLO v2 object detection inference on NNabla with pretrained weights available at [the original author's website](https://pjreddie.com/darknet/yolo/).
+
+There are two examples that run the object detection model. One is on Python API, another is on ROS C++ node.
+
+### On Python API
+
+This reqruires Python OpenCV. We would recommend you to install Python OpenCV to your Python by building from source using CMake command.
+
+1. Download the darknet model file from the web site.
+```
+python download_darknet_yolo.py
+```
+
+1. Convert the Darknet weight file to NNabla weights.
+```
+python convert_yolov2_weights_to_nnabla.py
+```
+
+1. Run detection. It runs YOLOv2 trained on MS COCO dataset given an image (`dog.jpg`), and outputs an image with bounding boxes `detect.dog.jpg` to the current folder.
+```
+python yolov2_detection.py [-c cudnn] dog.jpg
+```
+
+## On ROS C++ node
+
+NOTE: See [this page](https://github.com/sony/nnabla/tree/master/doc/build/README.md) for a build instruction of C++ libraries.
+
+1. Generate NNP format file for YOLOv2 inference. (Require the weight file created above.)
+```shell
+python yolov2_nnp.py
+```
+1. Copy the generated `coco.names` and `yolov2.nnp` to `./ros/nnabla_object_detection/data/`.
+1. Create a symbolic link to `nnabla_object_detection` at your catkin_workspace.
+1. Build your catkin workspace. The headers and so files of nnabla, nnabla_utils and nnabla_ext_cuda must be in paths. If you don't use a CUDA extension of NNabla, add `-DWITH_CUDA=OFF` to `catkin_make` command.
+1. Launch `roslaunch nnabla_object_detection demo.launch` with appropriate args. See the launch file for options.

--- a/object-detection/yolov2/convert_darknet19_weights_to_nnabla.py
+++ b/object-detection/yolov2/convert_darknet19_weights_to_nnabla.py
@@ -1,0 +1,57 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import darknet_parser as parser
+import nnabla as nn
+import darknet19
+import numpy as np
+
+
+def get_args():
+    import argparse
+    p = argparse.ArgumentParser()
+    p.add_argument('--input', default='darknet19.weights')
+    p.add_argument('--output', default=None)
+    args = p.parse_args()
+    if args.output is None:
+        args.output = args.input.replace('.weights', '.h5')
+    return args
+
+
+def main():
+    args = get_args()
+
+    # Defining network first
+    x = nn.Variable((1, 3, 224, 224))
+    y = darknet19.darknet19_classification(x / 255, test=True)
+
+    # Get NNabla parameters
+    params = nn.get_parameters(grad_only=False)
+
+    # Parse Darknet weights and store them into NNabla params
+    # Skip header by 4 integers
+    dn_weights = np.fromfile(args.input, dtype=np.float32)[4:]
+    cursor = 0
+    for i in range(1, 19):  # 1 to 18
+        cursor = parser.load_convolutional_and_get_next_cursor(
+            dn_weights, cursor, params, 'c{}'.format(i))
+    cursor = parser.load_convolutional_and_get_next_cursor(
+        dn_weights, cursor, params, 'c19', no_bn=True)
+
+    nn.save_parameters(args.output)
+
+
+if __name__ == '__main__':
+    main()

--- a/object-detection/yolov2/convert_yolov2_weights_to_nnabla.py
+++ b/object-detection/yolov2/convert_yolov2_weights_to_nnabla.py
@@ -1,0 +1,76 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import nnabla as nn
+
+import numpy as np
+
+import darknet_parser as parser
+import darknet19
+import yolov2
+
+
+def get_args():
+    ''' Parse arguments
+    '''
+    import argparse
+    p = argparse.ArgumentParser()
+    p.add_argument('--input', default='yolov2.weights')
+    p.add_argument('--output', default=None)
+    p.add_argument('--anchors', type=int, default=5)
+    p.add_argument('--classes', type=int, default=80)
+    p.add_argument('--width', type=int, default=608)
+    args = p.parse_args()
+    if args.output is None:
+        args.output = args.input.replace('.weights', '.h5')
+    return args
+
+
+def main():
+    '''Main.
+    '''
+
+    # Parse arguments
+    args = get_args()
+
+    # Create YOLOv2 detection newtork
+    x = nn.Variable((1, 3, args.width, args.width))
+    y = yolov2.yolov2(x, args.anchors, args.classes, test=True)
+    params = nn.get_parameters(grad_only=False)
+
+    # Parse network parameters
+    dn_weights = np.fromfile(args.input, dtype=np.float32)[4:]
+    cursor = 0
+    for i in range(1, 19):  # 1 to 18
+        cursor = parser.load_convolutional_and_get_next_cursor(
+            dn_weights, cursor, params, 'c{}'.format(i))
+    cursor = parser.load_convolutional_and_get_next_cursor(
+        dn_weights, cursor, params, 'c18_19')
+    cursor = parser.load_convolutional_and_get_next_cursor(
+        dn_weights, cursor, params, 'c18_20')
+    cursor = parser.load_convolutional_and_get_next_cursor(
+        dn_weights, cursor, params, 'c13_14')
+    cursor = parser.load_convolutional_and_get_next_cursor(
+        dn_weights, cursor, params, 'c21')
+    cursor = parser.load_convolutional_and_get_next_cursor(
+        dn_weights, cursor, params, 'detection', no_bn=True)
+    assert cursor == dn_weights.size
+
+    # Save to a h5 file
+    nn.save_parameters(args.output)
+
+
+if __name__ == '__main__':
+    main()

--- a/object-detection/yolov2/darknet19.py
+++ b/object-detection/yolov2/darknet19.py
@@ -1,0 +1,140 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import nnabla as nn
+import nnabla.functions as F
+import nnabla.parametric_functions as PF
+
+
+def conv_bn_pool(x, channels, kernel=3, act=F.leaky_relu, pool=True,
+                 test=False, name='cbp'):
+    '''
+    No doc.
+
+    '''
+    pad = 1 if kernel == 3 else 0
+    with nn.parameter_scope(name):
+        h = PF.convolution(x, channels, (kernel, kernel),
+                           pad=(pad, pad), with_bias=False)
+        h = PF.batch_normalization(h, batch_stat=not test)
+    h = act(h)
+    if pool:
+        h = F.max_pooling(h, (2, 2), (2, 2))
+    return h
+
+
+def darknet19_feature(x, act=F.leaky_relu, test=False, feature_dict=None):
+    '''
+
+    Args:
+        feature_dict (dict): If a dict given, the all variables of feature
+            maps before max pooling are pushed into the dict.
+
+    '''
+    # Layer configurations are composed of
+    # a list of (filters, kernel size, pooling or not)
+    layer_configs = [
+        # Unit1 (2)
+        (32, 3, True),
+        (64, 3, True),
+        # Unit2 (3)
+        (128, 3, False),
+        (64, 1, False),
+        (128, 3, True),
+        # Unit3 (3)
+        (256, 3, False),
+        (128, 1, False),
+        (256, 3, True),
+        # Unit4 (5)
+        (512, 3, False),
+        (256, 1, False),
+        (512, 3, False),
+        (256, 1, False),
+        (512, 3, True),
+        # Unit5 (5)
+        (1024, 3, False),
+        (512, 1, False),
+        (1024, 3, False),
+        (512, 1, False),
+        (1024, 3, False),
+    ]
+    h = x
+    for i, config in enumerate(layer_configs):
+        c, k, p = config
+        name = 'c{}'.format(i + 1)
+        h = conv_bn_pool(h, c, k, act=act, pool=p,
+                         name=name, test=test)
+        if feature_dict is not None:
+            if h.parent.name.startswith('MaxPooling'):
+                feature_dict[name] = h.parent.inputs[0]
+    return h
+
+
+def darknet19_classification(x, num_class=1000, act=F.leaky_relu, test=False):
+    '''
+    '''
+    h = darknet19_feature(x, act, test=test)
+    h = PF.convolution(h, num_class, (1, 1), name='c19')
+    h = F.mean(h, axis=(2, 3))
+    return h
+
+
+# Parser utilities of Darknet19
+def get_convolutional_params(params, prefix, no_bn=False):
+    '''
+    Returns conv/W, bn/beta, bn/gamma, bn/mean, bn/var
+
+    '''
+    if no_bn:
+        return (
+            params['/'.join((prefix, 'conv/W'))],
+            params['/'.join((prefix, 'conv/b'))],
+        )
+    return (
+        params['/'.join((prefix, 'conv/W'))],
+        params['/'.join((prefix, 'bn/beta'))],
+        params['/'.join((prefix, 'bn/gamma'))],
+        params['/'.join((prefix, 'bn/mean'))],
+        params['/'.join((prefix, 'bn/var'))],
+    )
+
+
+def set_param_and_get_next_cursor(dn_params, cursor, param):
+    '''
+    '''
+    param.d = dn_params[cursor:cursor + param.size].reshape(param.shape)
+    return cursor + param.size
+
+
+def load_convolutional_and_get_next_cursor_core(dn_params, cursor, w, b,
+                                                g=None, m=None, v=None):
+    '''
+    '''
+    cursor = set_param_and_get_next_cursor(dn_params, cursor, b)
+    if g is not None:
+        assert (m is not None and v is not None)
+        cursor = set_param_and_get_next_cursor(dn_params, cursor, g)
+        cursor = set_param_and_get_next_cursor(dn_params, cursor, m)
+        cursor = set_param_and_get_next_cursor(dn_params, cursor, v)
+    cursor = set_param_and_get_next_cursor(dn_params, cursor, w)
+    return cursor
+
+
+def load_convolutional_and_get_next_cursor(dn_params, cursor,
+                                           params, prefix, no_bn=False):
+    '''
+    '''
+    return load_convolutional_and_get_next_cursor_core(
+        dn_params, cursor, *get_convolutional_params(params, prefix, no_bn))

--- a/object-detection/yolov2/darknet19_classification.py
+++ b/object-detection/yolov2/darknet19_classification.py
@@ -1,0 +1,78 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import nnabla as nn
+import nnabla.functions as F
+
+import darknet19
+
+import numpy as np
+import time
+from scipy.misc import imread, imresize
+
+
+def get_args():
+    import argparse
+
+    p = argparse.ArgumentParser()
+    p.add_argument('--context', '-c', default='cpu', help='cpu|cuda.cudnn')
+    p.add_argument('--weights', '-w', default='darknet19.h5',
+                   help='NNabla parameters h5')
+    p.add_argument('--input', '-i', default='dog.jpg',
+                   help='path to input image')
+    p.add_argument('--size', '-s', default=224, help='Image width and height')
+    args = p.parse_args()
+    return args
+
+
+def main():
+    args = get_args()
+    from nnabla.contrib.context import extension_context
+    ctx = extension_context(args.context)
+    nn.set_default_context(ctx)
+
+    nn.load_parameters(args.weights)
+    x = nn.Variable((1, 3, args.size, args.size))
+    y = darknet19.darknet19_classification(x / 255, test=True)
+
+    label_names = np.loadtxt('imagenet.shortnames.list',
+                             dtype=str, delimiter=',')[:1000]
+
+    img = imread(args.input)
+    img = imresize(img, (args.size, args.size))
+
+    x.d = img.transpose(2, 0, 1).reshape(1, 3, args.size, args.size)
+    y.forward(clear_buffer=True)
+
+    # softmax
+    p = F.reshape(F.mul_scalar(F.softmax(y.data), 100), (y.size,))
+
+    # Show top-5 prediction
+    inds = np.argsort(y.d.flatten())[::-1][:5]
+    for i in inds:
+        print('{}: {:.1f}%'.format(label_names[i], p.data[i]))
+
+    s = time.time()
+    n_time = 10
+    for i in range(n_time):
+        y.forward(clear_buffer=True)
+    # Invoking device-to-host copy to synchronize the device (if CUDA).
+    _ = y.d
+    print("Processing time: {:.1f} [ms/image]".format(
+        (time.time() - s) / n_time * 1000))
+
+
+if __name__ == '__main__':
+    main()

--- a/object-detection/yolov2/darknet_parser.py
+++ b/object-detection/yolov2/darknet_parser.py
@@ -1,0 +1,66 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+'''
+Parser utilities for Darknet weight files,
+used inside functions in darknet19.py or yolov2.py.
+'''
+
+
+def get_convolutional_params(params, prefix, no_bn=False):
+    '''
+    Returns conv/W, bn/beta, bn/gamma, bn/mean, bn/var
+
+    '''
+    if no_bn:
+        return (
+            params['/'.join((prefix, 'conv/W'))],
+            params['/'.join((prefix, 'conv/b'))],
+        )
+    return (
+        params['/'.join((prefix, 'conv/W'))],
+        params['/'.join((prefix, 'bn/beta'))],
+        params['/'.join((prefix, 'bn/gamma'))],
+        params['/'.join((prefix, 'bn/mean'))],
+        params['/'.join((prefix, 'bn/var'))],
+    )
+
+
+def set_param_and_get_next_cursor(dn_params, cursor, param):
+    '''
+    '''
+    param.d = dn_params[cursor:cursor + param.size].reshape(param.shape)
+    return cursor + param.size
+
+
+def load_convolutional_and_get_next_cursor_core(dn_params, cursor, w, b,
+                                                g=None, m=None, v=None):
+    '''
+    '''
+    cursor = set_param_and_get_next_cursor(dn_params, cursor, b)
+    if g is not None:
+        assert (m is not None and v is not None)
+        cursor = set_param_and_get_next_cursor(dn_params, cursor, g)
+        cursor = set_param_and_get_next_cursor(dn_params, cursor, m)
+        cursor = set_param_and_get_next_cursor(dn_params, cursor, v)
+    cursor = set_param_and_get_next_cursor(dn_params, cursor, w)
+    return cursor
+
+
+def load_convolutional_and_get_next_cursor(dn_params, cursor,
+                                           params, prefix, no_bn=False):
+    '''
+    '''
+    return load_convolutional_and_get_next_cursor_core(
+        dn_params, cursor, *get_convolutional_params(params, prefix, no_bn))

--- a/object-detection/yolov2/download_darknet_yolo.py
+++ b/object-detection/yolov2/download_darknet_yolo.py
@@ -1,0 +1,34 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+def download(url):
+    from nnabla.utils.data_source_loader import download as dl
+    dl(url, url.split('/')[-1], False)
+
+
+def main():
+    categories = 'https://raw.githubusercontent.com/pjreddie/darknet/master/data/coco.names'
+    weights = 'https://pjreddie.com/media/files/yolov2.weights'
+    example_image = 'https://raw.githubusercontent.com/pjreddie/darknet/master/data/dog.jpg'
+    print('Downloading MS COCO category names ...')
+    download(categories)
+    print('Downloading Darknet YOLO weights ...')
+    download(weights)
+    print('Downloading an example image ...')
+    download(example_image)
+
+
+if __name__ == '__main__':
+    main()

--- a/object-detection/yolov2/ros/.gitignore
+++ b/object-detection/yolov2/ros/.gitignore
@@ -1,0 +1,1 @@
+catkin_workspace/

--- a/object-detection/yolov2/ros/nnabla_object_detection/CMakeLists.txt
+++ b/object-detection/yolov2/ros/nnabla_object_detection/CMakeLists.txt
@@ -1,0 +1,65 @@
+cmake_minimum_required(VERSION 2.8.3)
+project(nnabla_object_detection)
+
+# Options
+option(WITH_CUDA "Build with CUDA extension" ON)
+if (NOT WITH_CUDA)
+  add_definitions(-DWITHOUT_CUDA)
+endif()
+
+## Compile as C++11, supported in ROS Kinetic and newer
+add_compile_options(-std=c++11)
+
+## Find catkin macros and libraries
+find_package(catkin REQUIRED COMPONENTS
+  cv_bridge
+  image_transport
+  roscpp
+  sensor_msgs
+  std_msgs
+  )
+
+# OpenCV
+find_package(OpenCV REQUIRED)
+include_directories(${OpenCV_INCLUDE_DIRS})
+
+################################################
+## Declare ROS messages, services and actions ##
+################################################
+
+
+###################################
+## catkin specific configuration ##
+###################################
+catkin_package()
+
+###########
+## Build ##
+###########
+
+## Specify additional locations of header files
+include_directories(
+  ${catkin_INCLUDE_DIRS}
+)
+
+## Declare a C++ executable
+add_executable(${PROJECT_NAME}_detection_node src/detection_node.cpp)
+
+## Rename C++ executable without prefix
+set_target_properties(${PROJECT_NAME}_detection_node PROPERTIES OUTPUT_NAME detection PREFIX "")
+
+## Add cmake target dependencies of the executable
+add_dependencies(${PROJECT_NAME}_detection_node ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
+
+## Specify libraries to link a library or executable target against
+target_link_libraries(${PROJECT_NAME}_detection_node
+  ${catkin_LIBRARIES}
+  ${OpenCV_LIBS}
+  nnabla
+  nnabla_utils
+  )
+if(WITH_CUDA)
+  target_link_libraries(${PROJECT_NAME}_detection_node
+    nnabla_cuda
+    )
+endif()

--- a/object-detection/yolov2/ros/nnabla_object_detection/launch/demo.launch
+++ b/object-detection/yolov2/ros/nnabla_object_detection/launch/demo.launch
@@ -1,0 +1,35 @@
+<!--
+Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+<launch>
+  <!-- Args -->
+  <arg name="image_topic" default="/usb_cam/image_raw"/>
+  <arg name="run_usb_cam" default="true"/>
+  <arg name="video_device" default="/dev/video0"/>
+
+  <!-- NNabla detection node -->
+  <node name="detection" pkg="nnabla_object_detection" type="detection" output="screen">
+    <param name="image_topic" value="$(arg image_topic)"/>
+    <param name="nnp_file" value="$(find nnabla_object_detection)/data/yolov2.nnp"/>
+    <param name="class_meta_file" value="$(find nnabla_object_detection)/data/coco.names"/>
+    <param name="executor_name" value="runtime"/>
+  </node>
+
+  <!--USB camera -->
+  <node if="$(arg run_usb_cam)" name="usb_cam" pkg="usb_cam" type="usb_cam_node" output="screen">
+    <param name="video_device" value="$(arg video_device)"/>
+  </node>
+</launch>

--- a/object-detection/yolov2/ros/nnabla_object_detection/launch/video_file.launch
+++ b/object-detection/yolov2/ros/nnabla_object_detection/launch/video_file.launch
@@ -1,0 +1,24 @@
+<launch>
+  <!-- args -->
+  <arg name="video_stream_provider" default=""/>
+  <!-- launch video stream -->
+  <include file="$(find video_stream_opencv)/launch/camera.launch" >
+    <!-- node name and ros graph name -->
+    <arg name="camera_name" value="videofile" />
+    <!-- full path to the video file -->
+    <arg name="video_stream_provider" value="$(arg video_stream_provider)" />
+    <!-- throttling the querying of frames to -->
+    <arg name="fps" value="30" />
+    <!-- setting frame_id -->
+    <arg name="frame_id" value="videofile_frame" />
+    <!-- camera info loading, take care as it needs the "file:///" at the start , e.g.:
+	 "file:///$(find your_camera_package)/config/your_camera.yaml" -->
+    <arg name="camera_info_url" value="" />
+    <!-- flip the image horizontally (mirror it) -->
+    <arg name="flip_horizontal" value="false" />
+    <!-- flip the image vertically -->
+    <arg name="flip_vertical" value="false" />
+    <!-- visualize on an image_view window the stream generated -->
+    <arg name="visualize" value="true" />
+  </include>
+</launch>

--- a/object-detection/yolov2/ros/nnabla_object_detection/package.xml
+++ b/object-detection/yolov2/ros/nnabla_object_detection/package.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0"?>
+<package format="2">
+  <name>nnabla_object_detection</name>
+  <version>0.0.0</version>
+  <description>The nnabla_object_detection package</description>
+  <maintainer email="Takuya.Narihira@sony.com">Takuya.Narihira</maintainer>
+  <license>Apache 2.0</license>
+  <url type="website">https://nnabla.org/</url>
+  <buildtool_depend>catkin</buildtool_depend>
+  <build_depend>cv_bridge</build_depend>
+  <build_depend>image_transport</build_depend>
+  <build_depend>roscpp</build_depend>
+  <build_depend>sensor_msgs</build_depend>
+  <build_depend>std_msgs</build_depend>
+  <build_export_depend>cv_bridge</build_export_depend>
+  <build_export_depend>image_transport</build_export_depend>
+  <build_export_depend>roscpp</build_export_depend>
+  <build_export_depend>sensor_msgs</build_export_depend>
+  <build_export_depend>std_msgs</build_export_depend>
+  <exec_depend>cv_bridge</exec_depend>
+  <exec_depend>image_transport</exec_depend>
+  <exec_depend>roscpp</exec_depend>
+  <exec_depend>sensor_msgs</exec_depend>
+  <exec_depend>std_msgs</exec_depend>
+
+  <!-- The export tag contains other, unspecified, tags -->
+  <export>
+    <!-- Other tools can request additional information be placed here -->
+
+  </export>
+</package>

--- a/object-detection/yolov2/ros/nnabla_object_detection/src/detection_node.cpp
+++ b/object-detection/yolov2/ros/nnabla_object_detection/src/detection_node.cpp
@@ -1,0 +1,226 @@
+// Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <cv_bridge/cv_bridge.h>
+#include <image_transport/image_transport.h>
+#include <opencv2/highgui/highgui.hpp>
+#include <opencv2/imgproc/imgproc.hpp>
+#include <ros/ros.h>
+#include <sensor_msgs/image_encodings.h>
+
+#include <nbla_utils/nnp.hpp>
+#ifndef WITHOUT_CUDA
+#include <nbla/cuda/cudnn/init.hpp>
+#include <nbla/cuda/init.hpp>
+#endif
+
+#include <chrono>
+#include <fstream>
+
+using std::string;
+using std::shared_ptr;
+using std::vector;
+
+static const std::string OPENCV_WINDOW = "Image window";
+
+class NnablaObjectDetector {
+  ros::NodeHandle nh_;
+  ros::NodeHandle pnh_{"~"};
+  image_transport::ImageTransport it_;
+  image_transport::Subscriber image_sub_;
+  image_transport::Publisher image_pub_;
+
+  nbla::Context ctx_cpu_{{"cpu:float"}, "CpuCachedArray", "0"};
+#ifdef WITHOUT_CUDA
+  nbla::Context ctx_{{"cpu:float"}, "CpuCachedArray", "0"};
+#else
+  // TODO: devcie ID.
+  // Replace with the following context if you want to use half type (FP16)
+  // and TensorCore (available since Volta)
+  // nbla::Context ctx_{
+  //     {"cudnn:half", "cuda:half", "cpu:float"}, "CudaCachedArray", "0"};
+  nbla::Context ctx_{
+      {"cudnn:float", "cuda:float", "cpu:float"}, "CudaCachedArray", "0"};
+
+#endif
+  vector<cv::Scalar> colors_; // Color table for bounding boxes.
+  vector<string> classes_;    // Class names
+  shared_ptr<nbla::utils::nnp::Executor> executor_;
+
+  // params
+  string nnp_file_;
+  string class_meta_file_;
+  string executor_name_;
+  string image_topic_;
+
+  inline int transform_coord(float x, int size) {
+    return std::max(0, std::min((int)(x * size), size - 1));
+  }
+
+  void read_class_meta_file() {
+    std::ifstream ifs(class_meta_file_);
+    assert(ifs.is_open());
+    classes_.clear();
+    string buff;
+    while (std::getline(ifs, buff)) {
+      classes_.push_back(buff);
+    }
+  }
+
+  void create_color_table() {
+    cv::RNG rng(313);
+    colors_.clear();
+    for (int i = 0; i < classes_.size(); i++) {
+      colors_.push_back(cv::Scalar(rng(256), rng(256), rng(256)));
+    }
+  }
+
+public:
+  NnablaObjectDetector() : it_(nh_) {
+    init_params();
+    init_comm();
+    init_nnabla();
+    cv::namedWindow(OPENCV_WINDOW);
+    read_class_meta_file();
+    create_color_table();
+  }
+
+  void init_params() {
+    pnh_.param("nnp_file", nnp_file_, std::string("yolov2.nnp"));
+    pnh_.param("class_meta_file", class_meta_file_, std::string("coco.names"));
+    pnh_.param("executor_name", executor_name_, std::string("runtime"));
+    pnh_.param("image_topic", image_topic_, std::string("/usb_cam/image_raw"));
+  }
+
+  void init_comm() {
+    image_sub_ =
+        it_.subscribe(image_topic_, 1, &NnablaObjectDetector::imageCb, this);
+    image_pub_ = it_.advertise("/image_converter/output_video", 1);
+  }
+
+  void init_nnabla() {
+#ifndef WITHOUT_CUDA
+    nbla::init_cudnn();
+#endif
+
+    nbla::utils::nnp::Nnp nnp(ctx_);
+    nnp.add(nnp_file_);
+    executor_ = nnp.get_executor(executor_name_);
+    executor_->set_batch_size(1);
+  }
+
+  ~NnablaObjectDetector() { cv::destroyWindow(OPENCV_WINDOW); }
+
+  void imageCb(const sensor_msgs::ImageConstPtr &msg) {
+    cv_bridge::CvImagePtr cv_ptr;
+    try {
+      cv_ptr = cv_bridge::toCvCopy(msg, sensor_msgs::image_encodings::BGR8);
+    } catch (cv_bridge::Exception &e) {
+      ROS_ERROR("cv_bridge exception: %s", e.what());
+      return;
+    }
+    auto orig_size = cv_ptr->image.size();
+
+    nbla::CgVariablePtr x = executor_->get_data_variables().at(0).variable;
+    uint8_t *data = x->variable()->cast_data_and_get_pointer<uint8_t>(ctx_cpu_);
+    assert(x->variable()->ndim() == 4);
+    auto inshape = x->variable()->shape();
+    const int C = inshape[1];
+    const int H = inshape[2];
+    const int W = inshape[3];
+    assert(C == 3);
+
+    cv::Mat resized;
+    cv::resize(cv_ptr->image, resized, cv::Size{W, H});
+    for (int hw = 0; hw < H * W; ++hw) {
+      for (int c = 0; c < C; ++c) {
+        data[c * H * W + hw] = resized.ptr()[hw * C + 2 - c];
+      }
+    }
+
+    auto start = std::chrono::steady_clock::now();
+    executor_->execute();
+    auto end = std::chrono::steady_clock::now();
+    ROS_INFO(
+        "Input=%dx%dx%d FPS = %.1lf", H, W, C,
+        1e+6 /
+            std::chrono::duration_cast<std::chrono::microseconds>(end - start)
+                .count());
+
+    // Get output as a CPU array;
+    nbla::CgVariablePtr y = executor_->get_output_variables().at(0).variable;
+    const float *y_data = y->variable()->get_data_pointer<float>(ctx_cpu_);
+    assert(y->variable()->ndim() == 3);
+    auto outshape = y->variable()->shape();
+    int num_classes = (int)classes_.size();
+    int num_c = 5 + num_classes;
+    assert(outshape[2] == num_c);
+
+    // Draw boxes.
+    // cv::Mat img_draw(cv_ptr->image);
+    cv::Mat img_draw(resized);
+    for (int b = 0; b < outshape[1]; ++b) {
+      float score = -1;
+      int class_idx = 0;
+      for (int k = 0; k < num_classes; ++k) {
+        const float score_k = y_data[b * num_c + 5 + k];
+        if (score_k > score) {
+          class_idx = k;
+          score = score_k;
+        }
+      }
+      if (score <= 0) {
+        continue;
+      }
+      const float x = y_data[b * num_c + 0];
+      const float y = y_data[b * num_c + 1];
+      const float w = y_data[b * num_c + 2];
+      const float h = y_data[b * num_c + 3];
+#if 0
+      const int x0 = transform_coord(x - w / 2, orig_size.width);
+      const int y0 = transform_coord(y - h / 2, orig_size.height);
+      const int x1 = transform_coord(x + w / 2, orig_size.width);
+      const int y1 = transform_coord(y + h / 2, orig_size.height);
+#else
+      const int x0 = transform_coord(x - w / 2, W);
+      const int y0 = transform_coord(y - h / 2, H);
+      const int x1 = transform_coord(x + w / 2, W);
+      const int y1 = transform_coord(y + h / 2, H);
+#endif
+      // Object detection with deep learning and OpenCV
+      // https://goo.gl/q4RdcZ
+      cv::rectangle(img_draw, {x0, y0}, {x1, y1}, colors_.at(class_idx), 2);
+      int text_y0 = y0 + ((y0 > 30) ? -15 : 15);
+      string label = nbla::format_string(
+          "%s: %.2f%%", classes_.at(class_idx).c_str(), score * 100);
+      cv::putText(img_draw, label, {x0, text_y0}, cv::FONT_HERSHEY_SIMPLEX, 0.5,
+                  colors_.at(class_idx), 2);
+      ROS_INFO("Detected: %s.", label.c_str());
+    }
+
+    // Update GUI Window
+    cv::imshow(OPENCV_WINDOW, img_draw);
+    cv::waitKey(3);
+
+    // Output modified video stream
+    image_pub_.publish(cv_ptr->toImageMsg());
+  }
+};
+
+int main(int argc, char **argv) {
+  ros::init(argc, argv, "nnabla_object_detection");
+  NnablaObjectDetector ic;
+  ros::spin();
+  return 0;
+}

--- a/object-detection/yolov2/yolov2.py
+++ b/object-detection/yolov2/yolov2.py
@@ -1,0 +1,201 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import nnabla as nn
+import nnabla.functions as F
+import nnabla.parametric_functions as PF
+
+from darknet19 import conv_bn_pool, darknet19_feature
+
+
+def reorg_ref(x, stride):
+    import numpy as np
+    batch, out_c, h, w = x.shape
+    c = int(out_c * stride * stride)
+    h = int(h / stride)
+    w = int(w / stride)
+    y = np.zeros_like(x).flatten()
+    x = x.flatten()
+    out_c = int(c / (stride * stride))
+    for i in range(x.size):
+        in_index = i
+        in_w = i % w
+        i = int(i / w)
+        in_h = i % h
+        i = int(i / h)
+        in_c = i % c
+        i = int(i / c)
+        b = i % batch
+        c2 = in_c % out_c
+        offset = int(in_c / out_c)
+        w2 = in_w * stride + offset % stride
+        h2 = in_h * stride + int(offset / stride)
+        out_index = w2 + w * stride * (h2 + h * stride * (c2 + out_c * b))
+        y[in_index] = x[out_index]
+    return y.reshape(batch, c, h, w)
+
+
+def reorg_ref_darknet(x, stride):
+    import numpy as np
+    batch, c, h, w = x.shape
+    y = np.zeros_like(x).flatten()
+    x = x.flatten()
+    out_c = int(c / (stride * stride))
+    for i in range(x.size):
+        in_index = i
+        in_w = i % w
+        i = int(i / w)
+        in_h = i % h
+        i = int(i / h)
+        in_c = i % c
+        i = int(i / c)
+        b = i % batch
+        c2 = in_c % out_c
+        offset = int(in_c / out_c)
+        w2 = in_w * stride + offset % stride
+        h2 = in_h * stride + int(offset / stride)
+        out_index = w2 + w * stride * (h2 + h * stride * (c2 + out_c * b))
+        y[in_index] = x[out_index]
+    return y.reshape(batch, c * stride * stride, int(h / stride), int(w / stride))
+
+
+def reorg(x, stride):
+    # Input shape
+    b, c, h, w = x.shape
+    # Output shape
+    assert h % stride == 0
+    assert w % stride == 0
+    C, H, W = stride * stride * c, int(h / stride), int(w / stride)
+    # Reorg opration in Darknet can be done by transpose and reshape.
+    r = F.reshape(x, (b, c, H, stride, W, stride))
+    r = F.transpose(r, (0, 3, 5, 1, 2, 4))
+    r = F.reshape(r, (b, C, H, W))
+    # Note that an actual computation is only fired at the transpose
+    # because `reshape` doesn't involve any computation.
+    return r
+
+
+def reorg_darknet_bug(x, stride):
+    '''Simulate DarkNet's reorg layer including an indexing bug.
+    '''
+    b, c, h, w = x.shape
+    assert h % stride == 0
+    assert w % stride == 0
+    c_bug, h_bug, h_bug = int(c / stride / stride), h * stride, w * stride
+    C_bug, H_bug, W_bug = c, h, w
+    C, H, W = stride * stride * c, int(h / stride), int(w / stride)
+    r = F.reshape(x, (b, c_bug, h, stride, w, stride))
+    r = F.transpose(r, (0, 3, 5, 1, 2, 4))
+    r = F.reshape(r, (b, C, H, W))
+    return r
+
+
+def yolov2_feature(c13, c18, test=False, feature_dict=None):
+    '''
+    '''
+    if feature_dict is None:
+        feature_dict = {}
+    # Extra feature extraction for c18
+    h = conv_bn_pool(c18, 1024, 3, pool=False, test=test, name='c18_19')
+    feature_dict['c18_19'] = h
+    h = conv_bn_pool(h, 1024, 3, pool=False, test=test, name='c18_20')
+    feature_dict['c18_20'] = h
+
+    # Extra feature extraction for c13
+    c13_h = conv_bn_pool(c13, 64, 1, pool=False, test=test, name='c13_14')
+    feature_dict['c13_14'] = c13_h
+    c13_h = reorg_darknet_bug(c13_h, 2)
+    feature_dict['reorg'] = c13_h
+
+    # Concatenate c13 and c18 features together
+    h = F.concatenate(c13_h, h, axis=1)
+    feature_dict['route'] = h
+
+    # Extra feature extraction of the multi-scale features
+    h = conv_bn_pool(h, 1024, 3, pool=False, test=test, name='c21')
+    feature_dict['c21'] = h
+    return h
+
+
+def yolov2_detection_layer(h, num_anchors, num_classes):
+    '''
+    '''
+    return PF.convolution(h, (4 + 1 + num_classes) *
+                          num_anchors, (1, 1), name='detection')
+
+
+def yolov2(x, num_anchors, num_classes, test=False, feature_dict=None):
+    feature_dict_d = {}
+    c18 = darknet19_feature(x, test=test, feature_dict=feature_dict_d)
+    c13 = feature_dict_d['c13']
+    c21 = yolov2_feature(c13, c18, test=test, feature_dict=feature_dict)
+    det = yolov2_detection_layer(c21, num_anchors, num_classes)
+    if feature_dict is not None:
+        feature_dict.update(feature_dict_d)
+        feature_dict['c21'] = c21
+        feature_dict['det'] = det
+    return det
+
+
+def yolov2_activate(x, anchors, biases):
+    shape = x.shape
+    y = F.reshape(x, (shape[0], anchors, -1,) + shape[2:])
+    stop = list(y.shape)
+    stop[2] = 2
+    t_xy = F.slice(y, (0, 0, 0, 0, 0), stop)
+    stop[2] = 4
+    t_wh = F.slice(y, (0, 0, 2, 0, 0), stop)
+    stop[2] = 5
+    t_o = F.slice(y, (0, 0, 4, 0, 0), stop)
+    stop[2] = y.shape[2]
+    t_p = F.slice(y, (0, 0, 5, 0, 0), stop)
+    t_xy = F.sigmoid(t_xy)
+    t_wh = F.exp(t_wh)
+    t_o = F.sigmoid(t_o)
+    t_p = F.softmax(t_p, axis=2)
+    t_x, t_y, t_wh = yolov2_image_coordinate(t_xy, t_wh, biases)
+    y = F.concatenate(t_x, t_y, t_wh, t_o, t_p, axis=2)
+    y = F.transpose(y, (0, 1, 3, 4, 2)).reshape((
+        shape[0], -1, shape[1] / anchors))
+    return y
+
+
+def yolov2_image_coordinate(t_xy, t_wh, biases):
+    import numpy as np
+    from nnabla.parameter import pop_parameter, set_parameter
+    h, w = t_xy.shape[-2:]
+    xs = pop_parameter('xs')
+    ys = pop_parameter('ys')
+    if xs is None or (h != xs.shape[-1]):
+        xs = nn.Variable.from_numpy_array(np.arange(w).reshape(1, 1, 1, -1))
+        xs.need_grad = False
+        set_parameter('xs', xs)
+    if ys is None or (h != ys.shape[-2]):
+        ys = nn.Variable.from_numpy_array(np.arange(h).reshape(1, 1, -1, 1))
+        ys.need_grad = False
+        set_parameter('ys', ys)
+    t_x, t_y = F.split(t_xy, axis=2)
+    oshape = list(t_x.shape)
+    oshape.insert(2, 1)
+    t_x = F.reshape((t_x + xs) / w, oshape)
+    t_y = F.reshape((t_y + ys) / h, oshape)
+    pop_parameter('biases')
+    biases = biases.reshape(
+        1, biases.shape[0], biases.shape[1], 1, 1) / np.array([w, h]).reshape(1, 1, 2, 1, 1)
+    b = nn.Variable.from_numpy_array(biases)
+    b.need_grad = False
+    set_parameter('biases', b)
+    t_wh = t_wh * b
+    return t_x, t_y, t_wh

--- a/object-detection/yolov2/yolov2_detection.py
+++ b/object-detection/yolov2/yolov2_detection.py
@@ -1,0 +1,162 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import yolov2
+import cv2
+
+import nnabla as nn
+import nnabla.functions as F
+
+import time
+import numpy as np
+from scipy.misc import imread, imresize, imsave
+
+
+def get_args():
+    import argparse
+    from os.path import dirname, basename, join
+    p = argparse.ArgumentParser()
+    p.add_argument('--width', type=int, default=608)
+    p.add_argument('--weights', type=str, default='yolov2.h5')
+    p.add_argument('--context', '-c', type=str, default='cudnn')
+    p.add_argument('--device-id', '-d', type=str, default='0')
+    p.add_argument('--type-config', '-t', type=str, default='float')
+    p.add_argument('--output', type=str, default=None)
+    p.add_argument('--anchors', type=int, default=5)
+    p.add_argument('--classes', type=int, default=80)
+    p.add_argument('--class-names', type=str, default='coco.names')
+    p.add_argument('--thresh', type=float, default=.5)
+    p.add_argument('--nms', type=float, default=.45)
+    p.add_argument('--nms-per-class', type=bool, default=True)
+    p.add_argument(
+        '--biases', nargs='*',
+        default=[0.57273, 0.677385, 1.87446, 2.06253, 3.33843,
+                 5.47434, 7.88282, 3.52778, 9.77052, 9.16828])
+    p.add_argument('input', type=str, default='dog.jpg')
+    args = p.parse_args()
+    assert args.width % 32 == 0
+    assert len(args.biases) == args.anchors * 2
+    args.biases = np.array(args.biases).reshape(-1, 2)
+    if args.output is None:
+        args.output = join(dirname(args.input),
+                           'detect.' + basename(args.input))
+    return args
+
+
+def draw_bounding_boxes(img, bboxes, im_w, im_h, names, colors, sub_w, sub_h, thresh):
+    img_draw = img.copy()
+    for bb in bboxes:
+        if bb[4] <= 0:
+            continue
+        # x, y, w, h = bb[:4] * np.array([im_w, im_h, im_w, im_h])
+        x, y, w, h = bb[:4]
+        x = (x - (1 - sub_w) / 2.) / sub_w * im_w
+        y = (y - (1 - sub_h) / 2.) / sub_h * im_h
+        w = w * im_w / sub_w
+        h = h * im_h / sub_h
+        dw = w / 2.
+        dh = h / 2.
+        x0 = int(np.clip(x - dw, 0, im_w))
+        y0 = int(np.clip(y - dh, 0, im_h))
+        x1 = int(np.clip(x + dw, 0, im_w))
+        y1 = int(np.clip(y + dh, 0, im_h))
+        det_ind = np.where(bb[5:] > thresh)[0]
+        if len(det_ind) == 0:
+            continue
+        prob = bb[5 + det_ind]
+        # Object detection with deep learning and OpenCV
+        # https://goo.gl/q4RdcZ
+        label = ', '.join("{}: {:.2f}%".format(
+            names[det_ind[j]], prob[j] * 100) for j in range(len(det_ind)))
+        print("[INFO] {}".format(label))
+        cv2.rectangle(img_draw, (x0, y0), (x1, y1), colors[det_ind[0]], 2)
+        text_y0 = y0 - 15 if y0 - 15 > 15 else y0 + 15
+        cv2.putText(img_draw, label, (x0, text_y0),
+                    cv2.FONT_HERSHEY_SIMPLEX, 0.5, colors[det_ind[0]], 2)
+    return img_draw
+
+
+def main():
+    args = get_args()
+    names = np.genfromtxt(args.class_names, dtype=str, delimiter='?')
+    rng = np.random.RandomState(1223)
+    colors = rng.randint(0, 256, (args.classes, 3)).astype(np.uint8)
+    colors = [tuple(c.tolist()) for c in colors]
+
+    # Set context
+    from nnabla.ext_utils import get_extension_context
+    ctx = get_extension_context(
+        args.context, device_id=args.device_id, type_config=args.type_config)
+    nn.set_default_context(ctx)
+
+    # Load parameter
+    _ = nn.load_parameters(args.weights)
+
+    # Build a YOLO v2 network
+    feature_dict = {}
+    x = nn.Variable((1, 3, args.width, args.width))
+    y = yolov2.yolov2(x, args.anchors, args.classes,
+                      test=True, feature_dict=feature_dict)
+    y = yolov2.yolov2_activate(y, args.anchors, args.biases)
+    y = F.nms_detection2d(y, args.thresh, args.nms, args.nms_per_class)
+
+    # Read image
+    img_orig = imread(args.input)
+    im_h, im_w, _ = img_orig.shape
+    # letterbox
+    w = args.width
+    h = args.width
+
+    if (w * 1.0 / im_w) < (h * 1. / im_h):
+        new_w = w
+        new_h = int((im_h * w) / im_w)
+    else:
+        new_h = h
+        new_w = int((im_w * h) / im_h)
+
+    patch = imresize(img_orig, (new_h, new_w)) / 255.
+    img = np.ones((h, w, 3), np.float32) * 0.5
+    # resize
+    x0 = int((w - new_w) / 2)
+    y0 = int((h - new_h) / 2)
+    img[y0:y0 + new_h, x0:x0 + new_w] = patch
+
+    # Execute YOLO v2
+    print ("forward")
+    in_img = img.transpose(2, 0, 1).reshape(1, 3, args.width, args.width)
+    x.d = in_img
+    y.forward(clear_buffer=True)
+    print ("done")
+
+    bboxes = y.d[0]
+    img_draw = draw_bounding_boxes(
+        img_orig, bboxes, im_w, im_h, names, colors, new_w * 1.0 / w, new_h * 1.0 / h, args.thresh)
+    imsave(args.output, img_draw)
+
+    # Timing
+    s = time.time()
+    n_time = 10
+    for i in range(n_time):
+        x.d = in_img
+        y.forward(clear_buffer=True)
+        # Invoking device-to-host copy if CUDA
+        # so that time contains data transfer.
+        _ = y.d
+    print("Processing time: {:.1f} [ms/image]".format(
+        (time.time() - s) / n_time * 1000))
+
+
+if __name__ == '__main__':
+    main()

--- a/object-detection/yolov2/yolov2_nnp.py
+++ b/object-detection/yolov2/yolov2_nnp.py
@@ -1,0 +1,80 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import yolov2
+
+import nnabla as nn
+import nnabla.functions as F
+
+import time
+import numpy as np
+from scipy.misc import imread, imresize, imsave
+
+
+def get_args():
+    import argparse
+    from os.path import dirname, basename, join
+    p = argparse.ArgumentParser()
+    p.add_argument('--width', type=int, default=608)
+    p.add_argument('--height', type=int, default=608)
+    p.add_argument('--weights', type=str, default='yolo.h5')
+    p.add_argument('--anchors', type=int, default=5)
+    p.add_argument('--classes', type=int, default=80)
+    p.add_argument('--thresh', type=float, default=.5)
+    p.add_argument('--nms', type=float, default=.45)
+    p.add_argument('--nms-per-class', type=bool, default=True)
+    p.add_argument(
+        '--biases', nargs='*',
+        default=[0.57273, 0.677385, 1.87446, 2.06253, 3.33843,
+                 5.47434, 7.88282, 3.52778, 9.77052, 9.16828])
+    p.add_argument('--nnp', type=str, default='yolov2.nnp')
+    args = p.parse_args()
+    assert args.width % 32 == 0
+    assert args.height % 32 == 0
+    assert len(args.biases) == args.anchors * 2
+    args.biases = np.array(args.biases).reshape(-1, 2)
+    return args
+
+
+def main():
+    args = get_args()
+
+    # Load parameter
+    _ = nn.load_parameters(args.weights)
+
+    # Build a YOLO v2 network
+    x = nn.Variable((1, 3, args.height, args.width))
+    y = yolov2.yolov2(x / 255.0, args.anchors, args.classes, test=True)
+    y = yolov2.yolov2_activate(y, args.anchors, args.biases)
+    y = F.nms_detection2d(y, args.thresh, args.nms, args.nms_per_class)
+
+    # Save NNP file (used in C++ inference later.).
+    runtime_contents = {
+        'networks': [
+            {'name': 'runtime',
+             'batch_size': 1,
+             'outputs': {'y': y},
+             'names': {'x': x}}],
+        'executors': [
+            {'name': 'runtime',
+             'network': 'runtime',
+             'data': ['x'],
+             'output': ['y']}]}
+    import nnabla.utils.save
+    nnabla.utils.save.save(args.nnp, runtime_contents)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
This PR adds following examples which runs inferences of YOLO v2 using pretrained weights provided by the author of YOLO v2 at: https://pjreddie.com/darknet/yolov2/

* Python modules for YOLOv2 model
* Python inference script that runs YOLOv2 inference
* C++ ROS node example for integrating NNabla C++ YOLOv2 inference 

Reference paper: [Joseph Redmon, Ali Farhadi. YOLO9000: Better, Faster, Stronger.](https://arxiv.org/abs/1612.08242)

Depends on sony/nnabla#141.