### PR TITLE
Workaround fix for YOLO v2 and VAT until releasing sony/nnabla#220

### DIFF
--- a/GANs/pggan/trainer.py
+++ b/GANs/pggan/trainer.py
@@ -141,7 +141,7 @@ class Trainer:
                     z) if self.hyper_sphere else z
                 y = self.gen(z, test=True)
 
-                y.unlinked()
+                y.clear_all_graph_links()
                 y.need_grad = False
                 x_r = F.average_pooling(x, kernel=kernel)
 
@@ -229,7 +229,7 @@ class Trainer:
                 z = pixel_wise_feature_vector_normalization(
                     z) if self.hyper_sphere else z
                 y = self.gen.transition(z, alpha, test=True)
-                y.unlinked()
+                y.clear_all_graph_links()
                 y.need_grad = False
                 x_r = F.average_pooling(x, kernel=kernel)
 

--- a/imagenet-classification/classification.py
+++ b/imagenet-classification/classification.py
@@ -119,12 +119,20 @@ def train():
     t_model = get_model(
         args, num_classes, test=False, tiny=args.tiny_mode)
     t_model.pred.persistent = True  # Not clearing buffer of pred in backward
-    t_pred2 = t_model.pred.unlinked()
+
+    # TODO: need_grad should be passed to get_unlinked_variable after v1.0.3 fix.
+    t_pred2 = t_model.pred.get_unlinked_variable()
+    t_pred2.need_grad = False
+
     t_e = F.mean(F.top_n_error(t_pred2, t_model.label))
     v_model = get_model(
         args, num_classes, test=True, tiny=args.tiny_mode)
     v_model.pred.persistent = True  # Not clearing buffer of pred in forward
-    v_pred2 = v_model.pred.unlinked()
+
+    # TODO: need_grad should be passed to get_unlinked_variable after v1.0.3 fix.
+    v_pred2 = v_model.pred.get_unlinked_variable()
+    v_pred2.need_grad = False
+
     v_e = F.mean(F.top_n_error(v_pred2, v_model.label))
 
     # Create Solver.

--- a/imagenet-classification/multi_device_multi_process_classification.py
+++ b/imagenet-classification/multi_device_multi_process_classification.py
@@ -154,12 +154,20 @@ def train():
     t_model = get_model(
         args, num_classes, test=False, tiny=args.tiny_mode)
     t_model.pred.persistent = True  # Not clearing buffer of pred in backward
-    t_pred2 = t_model.pred.unlinked()
+
+    # TODO: need_grad should be passed to get_unlinked_variable after v1.0.3 fix.
+    t_pred2 = t_model.pred.get_unlinked_variable()
+    t_pred2.need_grad = False
+
     t_e = F.mean(F.top_n_error(t_pred2, t_model.label))
     v_model = get_model(
         args, num_classes, test=True, tiny=args.tiny_mode)
     v_model.pred.persistent = True  # Not clearing buffer of pred in forward
-    v_pred2 = v_model.pred.unlinked()
+
+    # TODO: need_grad should be passed to get_unlinked_variable after v1.0.3 fix.
+    v_pred2 = v_model.pred.get_unlinked_variable()
+    v_pred2.need_grad = False
+
     v_e = F.mean(F.top_n_error(v_pred2, v_model.label))
 
     # Add parameters to communicator.

--- a/mnist-collection/dcgan.py
+++ b/mnist-collection/dcgan.py
@@ -129,7 +129,8 @@ def train(args):
     pred_fake = discriminator(fake)
     loss_gen = F.mean(F.sigmoid_cross_entropy(
         pred_fake, F.constant(1, pred_fake.shape)))
-    fake_dis = fake.unlinked()
+    fake_dis = fake.get_unlinked_variable(need_grad=True)
+    fake_dis.need_grad = True  # TODO: Workaround until v1.0.2
     pred_fake_dis = discriminator(fake_dis)
     loss_dis = F.mean(F.sigmoid_cross_entropy(
         pred_fake_dis, F.constant(0, pred_fake_dis.shape)))

--- a/mnist-collection/vat.py
+++ b/mnist-collection/vat.py
@@ -234,7 +234,9 @@ def vat(x, r, eps, predict, distance):
     y = predict(x)
 
     # For stoping the backprop from this path.
-    y1 = y.unlinked()
+    # TODO: need_grad should be passed to get_unlinked_variable after v1.0.3 fix.
+    y1 = y.get_unlinked_variable()
+    y1.need_grad = False
 
     # Calculate log(p(y|x+n))
     y2 = predict(x + eps * r)

--- a/object-detection/yolov2/region_loss.py
+++ b/object-detection/yolov2/region_loss.py
@@ -142,8 +142,12 @@ def create_network(batchsize, imheight, imwidth, args):
     nH = yolo_features.shape[2]
     nW = yolo_features.shape[3]
 
-    output = yolo_features.unlinked()
-    output = output.reshape((nB, nA, (5+nC), nH, nW))
+    output = yolo_features.get_unlinked_variable(need_grad=True)
+    # TODO: Workaround until v1.0.2.
+    # Explicitly enable grad since need_grad option above didn't work.
+    output.need_grad = True
+
+    output = F.reshape(output, (nB, nA, (5 + nC), nH, nW))
     output_splitted = F.split(output, 2)
     x, y, w, h, conf = [v.reshape((nB, nA, nH, nW))
                         for v in output_splitted[0:5]]


### PR DESCRIPTION
Due to the bug described in sony/nnabla#220, YOLO v2 and VAT example didn't work. I applied a workaround fix to those.

I also modified  other examples such that those use the new API `get_unlinked_variable` rather than `unlinked` which is deprecated. 

In addition, fixed a minor issue in PGGAN example where `unlinked` function is incorrectly used. It seemed like intending to use `clear_all_graph_links`.