### PR TITLE
Fix/20180906 change default context argument

### DIFF
--- a/mnist-collection/README.md
+++ b/mnist-collection/README.md
@@ -28,7 +28,7 @@ you will see the training progress in the console (decreasing training and
 validation error). The model will eventually reach around 1% validation error
 rate.
 
-Training can be dramatically sped up by using a CUDA GPU when the
+Training can be dramatically speed up by using a CUDA GPU when the
 nnabla_ext-cuda extension is installed. Run the above command with `-c
 cudnn` option to let NNabla use GPU acceleration.
 

--- a/mnist-collection/args.py
+++ b/mnist-collection/args.py
@@ -52,7 +52,7 @@ def get_args(monitor_path='tmp.monitor', max_iter=10000, model_save_path=None, l
                         help='Path the model parameters saved.')
     parser.add_argument("--net", "-n", type=str,
                         default='lenet',
-                        help="Neural network architecture type (used only in classification*.py).\n  classification.py: ('lenet'|'resnet'),  classification_bnn.py: ('bincon'|'binnet'|'bwn'|'bwn'|'bincon_resnet'|'binnet_resnet'|'bwn_resnet')")
+                        help="Neural network architecture type (used only in classification*.py).\n  classification.py: ('lenet'|'resnet'),  classification_bnn.py: ('bincon'|'binnet'|'bwn'|'bincon_resnet'|'binnet_resnet'|'bwn_resnet')")
     parser.add_argument('--context', '-c', type=str,
                         default='cpu', help="Extension modules. ex) 'cpu', 'cudnn'.")
     parser.add_argument('--augment-train', action='store_true',

--- a/mnist-collection/vat.py
+++ b/mnist-collection/vat.py
@@ -294,7 +294,7 @@ def get_args():
     parser.add_argument("--model-save-path", "-o",
                         type=str, default="tmp.monitor.vat")
     parser.add_argument('--context', '-c', type=str,
-                        default=None, help="Extension path. ex) cpu, cudnn.")
+                        default="cpu", help="Extension path. ex) cpu, cudnn.")
     return parser.parse_args()
 
 

--- a/penn-treebank/args.py
+++ b/penn-treebank/args.py
@@ -23,7 +23,7 @@ def get_args():
     import os
     parser = argparse.ArgumentParser()
     parser.add_argument('--context', '-c', type=str,
-                        default=None, help="Extension path. ex) cpu, cudnn.")
+                        default="cudnn", help="Extension path. ex) cpu, cudnn.")
     parser.add_argument("--device-id", "-d", type=str, default='0',
                         help='Device ID the training run on. This is only valid if you specify `-c cudnn`.')
     parser.add_argument("--type-config", "-t", type=str, default='float',


### PR DESCRIPTION
I fixed typo in a doc and changed some default context arguments from none to cpu or cudnn.