### PR TITLE
Example of PyTorch-like parametric function classes

### DIFF
--- a/parametric_function_classes/mnist-collection/README.md
+++ b/parametric_function_classes/mnist-collection/README.md
@@ -1,0 +1,63 @@
+# PyTorch-like function in NNabla
+
+In NNabla, parametric functions (e.g., PF.convolution) are defined like TensorFlow V1.x, i.e., trainable parameters are managed in a global scope of a process by using a dictionary of a name of parameter to a trainable parameter and the scope context. It is intuitively straightforward when writing a code while a bit complicated to manage trainable parameters since trainable parameters are not managed in a local scope of e.g., a class but globally, which sometimes hard to see a whole picture of a neural network. If trainable parameters are held in a class like PyTorch or Chainer, it is very easy to see a whole picture of a network while being redundant representation of a network when writing a code since we have to write two lines about a parametric function to be used i.e., in the *\_\_init\_\_* method and *\_\_call\_\_* (or *forward*) method of a class. There are pros and cons for each, but people seem to like PyTorch-like parametric function definition.
+
+Currently, the following NNabla's parametric function classes are defined:
+
+- Convolution (Conv1d, Conv2d, Conv3d, ConvNd)
+- Deconvolution (Deconv1d, Deconv2d, Deconv3d, DeconvNd)
+- Affine (Linear)
+- Embed
+- BatchNorm (BatchNorm1d, BatchNorm2d, BatchNorm3d)
+
+
+# Usage
+
+```python
+...
+import nnabla.experimental.parametric_function_classes as PFC
+...
+
+...
+class ResUnit(PFC.Module):
+    def __init__(self, inmaps=64, outmaps=64):
+        self.conv0 = PFC.Conv2d(inmaps, inmaps // 2, (1, 1), (1, 1), (1, 1), with_bias=False)
+        self.bn0 = PFC.BatchNorm2d(inmaps // 2)
+        self.conv1 = PFC.Conv2d(inmaps // 2, inmaps // 2, (3, 3), (1, 1), (1, 1), with_bias=False)
+        self.bn1 = PFC.BatchNorm2d(inmaps // 2)
+        self.conv2 = PFC.Conv2d(maps // 2, outmaps, (1, 1), (1, 1), (1, 1), with_bias=False)
+        self.bn2 = PFC.BatchNorm2d(outmaps)
+        self.act = F.relu
+
+        self.shortcut_func = False
+        if inmaps != outmaps:
+            self.shortcut_func = True
+            self.shortcut_conv = PFC.Conv2d(inmaps, outmaps, (3, 3), (1, 1), (1, 1), with_bias=False)
+            self.shortcut_bn = PFC.BatchNorm2d(outmaps)
+
+    def __call__(self, x, test=False):
+        s = x
+        h = x
+        h = self.act(self.bn0(self.conv0(h), test))
+        h = self.act(self.bn1(self.conv1(h), test))
+        h = self.bn2(self.conv1(h), test)
+        if self.shortcut_func:
+          s = self.shortcut_conv(s)
+          s = self.shortcut_bn(s)
+        h = self.act(h + s)
+        return h
+...
+```
+
+It is easier to see the [main.py](./main.py) than describing how to use in details here.
+
+
+# Training Example
+
+[main.py](./main.py) includes almost everything to train NN by using *parametric function classes*, run the script like, 
+
+
+```bash
+python main.py
+```
+

--- a/parametric_function_classes/mnist-collection/main.py
+++ b/parametric_function_classes/mnist-collection/main.py
@@ -1,0 +1,114 @@
+import numpy as np
+
+import nnabla as nn
+import nnabla.functions as F
+import nnabla.solvers as S
+from nnabla.ext_utils import get_extension_context
+
+from mnist_data import data_iterator_mnist
+from nnabla.monitor import Monitor, MonitorSeries
+
+import nnabla.experimental.parametric_function_classes as PFC
+
+
+class Model0(PFC.Module):
+    def __init__(self):
+        self.conv0 = PFC.Conv2d(1, 16, (3, 3), pad=(1, 1), with_bias=False)
+        self.conv1 = PFC.Conv2d(16, 32, (3, 3), pad=(1, 1), with_bias=False)
+        self.bn0 = PFC.BatchNorm2d(16)
+        self.bn1 = PFC.BatchNorm2d(32)
+        self.act = F.relu
+        self.pool = F.max_pooling
+
+    def __call__(self, x, test=False):
+        h = x
+        h = self.conv0(h)
+        h = self.bn0(h, test)
+        h = self.act(h)
+        h = self.pool(h, (2, 2))
+        h = self.conv1(h)
+        h = self.bn1(h, test)
+        h = self.act(h)
+        h = self.pool(h, (2, 2))
+        return h
+
+
+class Model1(PFC.Module):
+    def __init__(self):
+        self.conv0 = PFC.Conv2d(32, 64, (3, 3), pad=(1, 1), with_bias=False)
+        self.bn0 = PFC.BatchNorm2d(64)
+        self.affine = PFC.Affine(64, 10)
+        self.act = F.relu
+        self.pool = F.average_pooling
+
+    def __call__(self, x, test=False):
+        h = x
+        h = self.conv0(h)
+        h = self.bn0(h, test)
+        h = self.act(h)
+        h = self.pool(h, h.shape[2:])
+        h = self.affine(h)
+        return h
+
+
+class Model(PFC.Module):
+    def __init__(self):
+        self.model0 = Model0()
+        self.model1 = Model1()
+
+    def __call__(self, x, test=False):
+        h = x if test else F.image_augmentation(x, flip_lr=True, angle=0.26)
+        h = self.model0(h, test)
+        h = self.model1(h, test)
+        return h
+
+
+def main():
+    # Context
+    ctx = get_extension_context("cudnn", device_id="0")
+    nn.set_default_context(ctx)
+    nn.auto_forward(False)
+    # Inputs
+    b, c, h, w = 64, 1, 28, 28
+    x = nn.Variable([b, c, h, w])
+    t = nn.Variable([b, 1])
+    vx = nn.Variable([b, c, h, w])
+    vt = nn.Variable([b, 1])
+    # Model
+    model = Model()
+    pred = model(x)
+    loss = F.softmax_cross_entropy(pred, t)
+    vpred = model(vx, test=True)
+    verror = F.top_n_error(vpred, vt)
+    # Solver
+    solver = S.Adam()
+    solver.set_parameters(model.get_parameters(grad_only=True))
+    # Data Iterator
+    tdi = data_iterator_mnist(b, train=True)
+    vdi = data_iterator_mnist(b, train=False)
+    # Monitor
+    monitor = Monitor("tmp.monitor")
+    monitor_loss = MonitorSeries("Training loss", monitor, interval=10)
+    monitor_verr = MonitorSeries("Test error", monitor, interval=1)
+
+    # Training loop
+    for e in range(1):
+        for j in range(tdi.size // b):
+            i = e * tdi.size // b + j
+            x.d, t.d = tdi.next()
+            solver.zero_grad()
+            loss.forward(clear_no_need_grad=True)
+            loss.backward(clear_buffer=True)
+            solver.update()
+            monitor_loss.add(i, loss.d)
+        error = 0.0
+        for _ in range(vdi.size // b):
+            vx.d, vt.d = vdi.next()
+            verror.forward(clear_buffer=True)
+            error += verror.d
+        error /= vdi.size // b
+        monitor_verr.add(i, error)
+
+
+if __name__ == '__main__':
+    main()

--- a/parametric_function_classes/mnist-collection/mnist_data.py
+++ b/parametric_function_classes/mnist-collection/mnist_data.py
@@ -1,0 +1,140 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+'''
+Provide data iterator for MNIST examples.
+'''
+import numpy
+import struct
+import zlib
+
+from nnabla.logger import logger
+from nnabla.utils.data_iterator import data_iterator
+from nnabla.utils.data_source import DataSource
+from nnabla.utils.data_source_loader import download
+
+
+def load_mnist(train=True):
+    '''
+    Load MNIST dataset images and labels from the original page by Yan LeCun or the cache file.
+
+    Args:
+        train (bool): The testing dataset will be returned if False. Training data has 60000 images, while testing has 10000 images.
+
+    Returns:
+        numpy.ndarray: A shape of (#images, 1, 28, 28). Values in [0.0, 1.0].
+        numpy.ndarray: A shape of (#images, 1). Values in {0, 1, ..., 9}.
+
+    '''
+    if train:
+        image_uri = 'http://yann.lecun.com/exdb/mnist/train-images-idx3-ubyte.gz'
+        label_uri = 'http://yann.lecun.com/exdb/mnist/train-labels-idx1-ubyte.gz'
+    else:
+        image_uri = 'http://yann.lecun.com/exdb/mnist/t10k-images-idx3-ubyte.gz'
+        label_uri = 'http://yann.lecun.com/exdb/mnist/t10k-labels-idx1-ubyte.gz'
+    logger.info('Getting label data from {}.'.format(label_uri))
+    # With python3 we can write this logic as following, but with
+    # python2, gzip.object does not support file-like object and
+    # urllib.request does not support 'with statement'.
+    #
+    #   with request.urlopen(label_uri) as r, gzip.open(r) as f:
+    #       _, size = struct.unpack('>II', f.read(8))
+    #       labels = numpy.frombuffer(f.read(), numpy.uint8).reshape(-1, 1)
+    #
+    r = download(label_uri)
+    data = zlib.decompress(r.read(), zlib.MAX_WBITS | 32)
+    _, size = struct.unpack('>II', data[0:8])
+    labels = numpy.frombuffer(data[8:], numpy.uint8).reshape(-1, 1)
+    r.close()
+    logger.info('Getting label data done.')
+
+    logger.info('Getting image data from {}.'.format(image_uri))
+    r = download(image_uri)
+    data = zlib.decompress(r.read(), zlib.MAX_WBITS | 32)
+    _, size, height, width = struct.unpack('>IIII', data[0:16])
+    images = numpy.frombuffer(data[16:], numpy.uint8).reshape(
+        size, 1, height, width)
+    r.close()
+    logger.info('Getting image data done.')
+
+    return images, labels
+
+
+class MnistDataSource(DataSource):
+    '''
+    Get data directly from MNIST dataset from Internet(yann.lecun.com).
+    '''
+
+    def _get_data(self, position):
+        image = self._images[self._indexes[position]]
+        label = self._labels[self._indexes[position]]
+        return (image, label)
+
+    def __init__(self, train=True, shuffle=False, rng=None):
+        super(MnistDataSource, self).__init__(shuffle=shuffle)
+        self._train = train
+
+        self._images, self._labels = load_mnist(train)
+
+        self._size = self._labels.size
+        self._variables = ('x', 'y')
+        if rng is None:
+            rng = numpy.random.RandomState(313)
+        self.rng = rng
+        self.reset()
+
+    def reset(self):
+        if self._shuffle:
+            self._indexes = self.rng.permutation(self._size)
+        else:
+            self._indexes = numpy.arange(self._size)
+        super(MnistDataSource, self).reset()
+
+    @property
+    def images(self):
+        """Get copy of whole data with a shape of (N, 1, H, W)."""
+        return self._images.copy()
+
+    @property
+    def labels(self):
+        """Get copy of whole label with a shape of (N, 1)."""
+        return self._labels.copy()
+
+
+def data_iterator_mnist(batch_size,
+                        train=True,
+                        rng=None,
+                        shuffle=True,
+                        with_memory_cache=False,
+                        with_parallel=False,
+                        with_file_cache=False):
+    '''
+    Provide DataIterator with :py:class:`MnistDataSource`
+    with_memory_cache, with_parallel and with_file_cache option's default value is all False,
+    because :py:class:`MnistDataSource` is able to store all data into memory.
+
+    For example,
+
+    .. code-block:: python
+
+        with data_iterator_mnist(True, batch_size) as di:
+            for data in di:
+                SOME CODE TO USE data.
+
+    '''
+    return data_iterator(MnistDataSource(train=train, shuffle=shuffle, rng=rng),
+                         batch_size,
+                         with_memory_cache,
+                         with_parallel,
+                         with_file_cache)


### PR DESCRIPTION
Currently, the following NNabla's parametric function classes are defined:

- Convolution (Conv1d, Conv2d, Conv3d, ConvNd)
- Deconvolution (Deconv1d, Deconv2d, Deconv3d, DeconvNd)
- Affine (Linear)
- Embed
- BatchNorm (BatchNorm1d, BatchNorm2d, BatchNorm3d)
