### PR TITLE
 EfficientNet B0, B1, B2, B3

### DIFF
--- a/imagenet-classification/README.md
+++ b/imagenet-classification/README.md
@@ -193,6 +193,21 @@ Training results are summarized as follows.
 * *1 Mixed precision training with NHWC layout  (`-t half --channel-last`).
 * *2 We used training configuration summarized above.
 
+### Training results (EfficientNet Family)
+
+Training results are summarized as follows.
+
+| Arch. | GPUs | MP*1 | Config*2 | Batch size per GPU | Training time (h) | Validation error (%) | Pretrained parameters (Click to download) | Note |
+|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---|
+| EfficientNet-B0 | 4 x V100 | Yes | Cos350 | 256 | 49.31 | 23.76  | Download: [Cos350](https://nnabla.org/pretrained-models/nnabla-examples/ilsvrc2012/efficientnet_b0_nchw_cos340.h5) | |
+| EfficientNet-B1 | 4 x V100 | Yes | Cos350 | 256 | 78.41 | 22.11  | Download: [Cos350](https://nnabla.org/pretrained-models/nnabla-examples/ilsvrc2012/efficientnet_b1_nchw_cos350.h5) | |
+| EfficientNet-B2 | 4 x V100 | Yes | Cos350 | 256 | 95.18 | 21.27  | Download: [Cos350](https://nnabla.org/pretrained-models/nnabla-examples/ilsvrc2012/efficientnet_b2_nchw_cos350.h5) | |
+| EfficientNet-B3 | 4 x V100 | Yes | Cos350 | 256 | 149.89 | 20.08  | Download: [Cos350](https://nnabla.org/pretrained-models/nnabla-examples/ilsvrc2012/efficientnet_b3_nchw_cos350.h5) | |
+
+
+* *1 Mixed precision training with NHWC layout  (`-t half --channel-last`).
+* *2 We used training configuration summarized above.
+
 ### Evalutation of pretrained model
 
 You can obtain Top-1 validation error rate with standard evaluation setting (256 scaling with center crop 224) of a trained model by using a command like below.

--- a/imagenet-classification/README.md
+++ b/imagenet-classification/README.md
@@ -183,12 +183,12 @@ Training results are summarized as follows.
 |:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---|
 | MobileNet-V1 | 4 x V100 | No | Cos90 | 256 | 8.63 | 27.77  | Download: [Cos90](https://nnabla.org/pretrained-models/nnabla-examples/ilsvrc2012/mbnv1_nchw_cos90.h5) | |
 | MobileNet-V2 | 4 x V100 | No | Cos90 | 256 | 9.66 | 28.06  | Download: [Cos90](https://nnabla.org/pretrained-models/nnabla-examples/ilsvrc2012/mbnv2_nchw_cos90.h5) | |
-| MobileNet-V3-Large | 4 x RTX 2080 Ti | No | Cos90 | 128 | 13.41 | 25.80 | Download: [Cos90](https://nnabla.org/pretrained-models/nnabla-examples/ilsvrc2012/mbnv3_large_nchw_cos90.h5) | |
-| MobileNet-V3-Samll | 4 x RTX 2080 Ti | No | Cos90 | 128 | 5.69 | 33.37  | Download: [Cos90](https://nnabla.org/pretrained-models/nnabla-examples/ilsvrc2012/mbnv3_small_nchw_cos90.h5) | |
+| MobileNet-V3-Large | 4 x V100 | No | Cos90 | 256 | 10.92 | 26.11 | Download: [Cos90](https://nnabla.org/pretrained-models/nnabla-examples/ilsvrc2012/mbnv3_large_nchw_cos90.h5) | |
+| MobileNet-V3-Samll | 4 x V100 | No | Cos90 | 256 | 5.32 | 33.87  | Download: [Cos90](https://nnabla.org/pretrained-models/nnabla-examples/ilsvrc2012/mbnv3_small_nchw_cos90.h5) | |
 | MobileNet-V1 | 4 x V100 | Yes | Cos90 | 256 | 6.35  | 27.63  | Download: [Cos90](https://nnabla.org/pretrained-models/nnabla-examples/ilsvrc2012/mbnv1_nhwc_cos90.h5) | |
 | MobileNet-V2 | 4 x V100 | Yes | Cos90 | 256 | 7.14  | 28.32  | Download: [Cos90](https://nnabla.org/pretrained-models/nnabla-examples/ilsvrc2012/mbnv2_nhwc_cos90.h5) | |
-| MobileNet-V3-Large | 4 x V100 | Yes | Cos90 | 256 | 8.09  | 25.98 | Download: [Cos90](https://nnabla.org/pretrained-models/nnabla-examples/ilsvrc2012/mbnv3_large_nhwc_cos90.h5) | |
-| MobileNet-V3-Samll | 4 x V100 | Yes | Cos90 | 256 | 5.96  | 33.64  | Download: [Cos90](https://nnabla.org/pretrained-models/nnabla-examples/ilsvrc2012/mbnv3_small_nhwc_cos90.h5) | |
+| MobileNet-V3-Large | 4 x V100 | Yes | Cos90 | 256 | 7.63  | 26.09 | Download: [Cos90](https://nnabla.org/pretrained-models/nnabla-examples/ilsvrc2012/mbnv3_large_nhwc_cos90.h5) | |
+| MobileNet-V3-Samll | 4 x V100 | Yes | Cos90 | 256 | 5.49  | 33.49  | Download: [Cos90](https://nnabla.org/pretrained-models/nnabla-examples/ilsvrc2012/mbnv3_small_nhwc_cos90.h5) | |
 
 * *1 Mixed precision training with NHWC layout  (`-t half --channel-last`).
 * *2 We used training configuration summarized above.

--- a/imagenet-classification/args.py
+++ b/imagenet-classification/args.py
@@ -110,6 +110,13 @@ def post_process_spatial_size(args):
         args.spatial_size = args.spatial_size * 2
 
 
+def post_process_spatial_size(args):
+    if isinstance(args.spatial_size, int):
+        args.spatial_size = (args.spatial_size, args.spatial_size)
+    elif len(args.spatial_size) == 1:
+        args.spatial_size = args.spatial_size * 2
+
+
 def get_train_args():
     """
     Get command line arguments.

--- a/imagenet-classification/models/mobilenet.py
+++ b/imagenet-classification/models/mobilenet.py
@@ -275,7 +275,6 @@ class MobileNetV3(MobileNetBase):
         cr = c // rr
         conv_opts = dict(channel_last=self.channel_last, with_bias=True)
         pool_shape = get_spatial_shape(x.shape, self.channel_last)
-
         h = F.average_pooling(x, pool_shape, channel_last=self.channel_last)
         with nn.parameter_scope(name):
             with nn.parameter_scope("fc1"):
@@ -296,7 +295,7 @@ class MobileNetV3(MobileNetBase):
         omaps = maps
         with nn.parameter_scope(name):
             h = self.conv_bn_act(h, hmaps, (1, 1), (1, 1),
-                                 act=act, name="conv-pw")
+                                 act=act, name="conv-pw") if ef != 1 else h
             h = self.conv_bn_act(h, hmaps, kernel, stride,
                                  group=hmaps, act=act, name="conv-dw")
             h = self.squeeze_and_excite(


### PR DESCRIPTION
-  Training Examples and Trained Models with our typical settings for EfficientNet B0, B1, B2, B3
-  Fix MobleNetV3 settings and trained models

MobleNetV3/EfficientNets with the mixup and train-longer comes later.