### PR TITLE
use basename if yaml filename is absolute path.

### DIFF
--- a/utils/neu/save_args.py
+++ b/utils/neu/save_args.py
@@ -30,5 +30,8 @@ def save_args(args, config=None):
             fp.write("{}={}\n".format(k, v))
 
             if config is not None and isinstance(v, str) and v.endswith(".yaml"):
-                path = os.path.join(args.monitor_path, v)
+                if os.path.isabs(v):
+                    path = os.path.join(args.monitor_path, os.path.basename(v))
+                else:
+                    path = os.path.join(args.monitor_path, v)
                 write_yaml(path, config)


### PR DESCRIPTION
save_args() writes yml file into monitor directory.
But if yaml file is specified with an absolute path, original yaml file will be overwritten.
This PR fix this issue.