### PR TITLE
fix device_id value and use built flatc

### DIFF
--- a/interactive-demos/quantization_tutorial.ipynb
+++ b/interactive-demos/quantization_tutorial.ipynb
@@ -56,6 +56,25 @@
    ]
   },
   {
+    "cell_type": "markdown",
+    "id": "g-nvQUIS5bYE",
+    "metadata": {},
+    "source": [
+      "* Build flatbuffers"
+    ]
+  },
+  {
+    "cell_type": "code",
+    "execution_count": null,
+    "id": "LYxkSo5k5kay",
+    "metadata": {},
+    "outputs": [],
+    "source": [
+      "!git clone https://github.com/google/flatbuffers.git\n",
+      "!cd flatbuffers && cmake -G \"Unix Makefiles\" && make"
+    ]
+  },
+  {
    "cell_type": "markdown",
    "id": "cebccb31",
    "metadata": {},
@@ -316,7 +335,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ctx = get_context('cudnn', '1')\n",
+    "ctx = get_context('cudnn', '0')\n",
     "nn.set_default_context(ctx)\n",
     "train()"
    ]
@@ -337,9 +356,9 @@
    "outputs": [],
    "source": [
     "# convert nnp to float32 tflite\n",
-    "!nnabla_cli convert -b 1 mnist.nnp mnist.tflite\n",
+    "!PATH=$PATH:$(pwd)/flatbuffers nnabla_cli convert -b 1 mnist.nnp mnist.tflite\n",
     "# convert nnp to int8 tflite\n",
-    "!nnabla_cli convert -b 1 mnist.nnp mnist_int8.tflite --quantization --dataset mnist.npy"
+    "!PATH=$PATH:$(pwd)/flatbuffers nnabla_cli convert -b 1 mnist.nnp mnist_int8.tflite --quantization --dataset mnist.npy"
    ]
   },
   {


### PR DESCRIPTION
Update tflite interactive demo to run on Google Colab environment.
* get_context() was specified '1', but '0' is better for 1 GPU environment.
* Google Colab doesn't have flatc and snap, so changed to use flatc built on colab.