### PR TITLE
Update colab demo to nnabla-ext-cuda114

### DIFF
--- a/interactive-demos/adversarial_debiasing.ipynb
+++ b/interactive-demos/adversarial_debiasing.ipynb
@@ -69,7 +69,7 @@
       "outputs": [],
       "source": [
         "# Preparation\n",
-        "!pip install nnabla-ext-cuda100\n",
+        "!pip install nnabla-ext-cuda114\n",
         "# for cpu set context as \"!pip install nnabla\"\n",
         "!git clone https://github.com/sony/nnabla-examples.git\n",
         "%cd nnabla-examples/responsible_ai/adversarial_debiasing\n",

--- a/interactive-demos/adversarial_debiasing_images.ipynb
+++ b/interactive-demos/adversarial_debiasing_images.ipynb
@@ -56,7 +56,7 @@
     "# Preparation\n",
     "!git clone https://github.com/sony/nnabla-examples.git\n",
     "%cd nnabla-examples/responsible_ai/adversarial_debiasing_images\n",
-    "!pip install nnabla-ext-cuda100\n",
+    "!pip install nnabla-ext-cuda114\n",
     "!pip install albumentations\n",
     "\n",
     "import cv2\n",

--- a/interactive-demos/attention_branch_network.ipynb
+++ b/interactive-demos/attention_branch_network.ipynb
@@ -60,7 +60,7 @@
    },
    "outputs": [],
    "source": [
-    "!pip install nnabla-ext-cuda100\n",
+    "!pip install nnabla-ext-cuda114\n",
     "!git clone https://github.com/sony/nnabla-examples.git\n",
     "%cd nnabla-examples"
    ]

--- a/interactive-demos/centernet.ipynb
+++ b/interactive-demos/centernet.ipynb
@@ -51,7 +51,7 @@
       "cell_type": "code",
       "metadata": {},
       "source": [
-        "!pip install nnabla-ext-cuda100\n",
+        "!pip install nnabla-ext-cuda114\n",
         "!git clone https://github.com/sony/nnabla-examples.git\n",
         "%cd nnabla-examples/object-detection/centernet"
       ],

--- a/interactive-demos/dataaugmentation.ipynb
+++ b/interactive-demos/dataaugmentation.ipynb
@@ -24,7 +24,7 @@
       "cell_type": "code",
       "metadata": {},
       "source": [
-        "!pip install nnabla-ext-cuda100\n",
+        "!pip install nnabla-ext-cuda114\n",
         "!git clone https://github.com/sony/nnabla-examples.git\n",
         "%run nnabla-examples/interactive-demos/colab_utils.py\n",
         "%cd nnabla-examples/data_augmentation"

--- a/interactive-demos/deep-exemplar-based-video-colorization.ipynb
+++ b/interactive-demos/deep-exemplar-based-video-colorization.ipynb
@@ -15,7 +15,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install nnabla-ext-cuda100"
+    "!pip install nnabla-ext-cuda114"
    ]
   },
   {

--- a/interactive-demos/eigencam.ipynb
+++ b/interactive-demos/eigencam.ipynb
@@ -41,7 +41,7 @@
    },
    "outputs": [],
    "source": [
-    "!pip install nnabla-ext-cuda100\n",
+    "!pip install nnabla-ext-cuda114\n",
     "!git clone https://github.com/sony/nnabla-examples.git\n",
     "%cd nnabla-examples/responsible_ai/eigencam"
    ]

--- a/interactive-demos/eigencam_for_CenterNet.ipynb
+++ b/interactive-demos/eigencam_for_CenterNet.ipynb
@@ -36,7 +36,7 @@
    },
    "outputs": [],
    "source": [
-    "!pip install nnabla-ext-cuda100\n",
+    "!pip install nnabla-ext-cuda114\n",
     "!git clone https://github.com/sony/nnabla-examples.git\n",
     "%cd nnabla-examples/object-detection/centernet"
    ]

--- a/interactive-demos/esrgan.ipynb
+++ b/interactive-demos/esrgan.ipynb
@@ -31,7 +31,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install nnabla-ext-cuda100\n",
+    "!pip install nnabla-ext-cuda114\n",
     "!git clone https://github.com/sony/nnabla-examples.git\n",
     "%cd nnabla-examples/image-superresolution/esrgan"
    ]

--- a/interactive-demos/fan.ipynb
+++ b/interactive-demos/fan.ipynb
@@ -31,7 +31,7 @@
       "cell_type": "code",
       "metadata": {},
       "source": [
-        "!pip install nnabla-ext-cuda100\n",
+        "!pip install nnabla-ext-cuda114\n",
         "!git clone https://github.com/sony/nnabla-examples.git\n",
         "%run nnabla-examples/interactive-demos/colab_utils.py\n",
         "%cd nnabla-examples/facial-keypoint-detection/face-alignment"

--- a/interactive-demos/fomm.ipynb
+++ b/interactive-demos/fomm.ipynb
@@ -26,7 +26,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install nnabla-ext-cuda100 imageio-ffmpeg\n",
+    "!pip install nnabla-ext-cuda114 imageio-ffmpeg\n",
     "!git clone https://github.com/sony/nnabla-examples.git\n",
     "%cd nnabla-examples/facial-motion-transfer/first-order-model"
    ]

--- a/interactive-demos/gan_data_debiasing.ipynb
+++ b/interactive-demos/gan_data_debiasing.ipynb
@@ -46,7 +46,7 @@
     "# Preparation\n",
     "!git clone https://github.com/sony/nnabla-examples.git\n",
     "%cd nnabla-examples/responsible_ai/gan_data_debiased\n",
-    "!pip install nnabla-ext-cuda100\n",
+    "!pip install nnabla-ext-cuda114\n",
     "!pip install albumentations\n",
     "\n",
     "import cv2\n",

--- a/interactive-demos/gradcam.ipynb
+++ b/interactive-demos/gradcam.ipynb
@@ -65,7 +65,7 @@
         "id": "FSxlbQDfGF0Y"
       },
       "source": [
-        "!pip install nnabla-ext-cuda100\n",
+        "!pip install nnabla-ext-cuda114\n",
         "!git clone https://github.com/sony/nnabla-examples.git\n",
         "%cd nnabla-examples/responsible_ai/gradcam"
       ],

--- a/interactive-demos/imagenet_classification.ipynb
+++ b/interactive-demos/imagenet_classification.ipynb
@@ -23,7 +23,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install nnabla-ext-cuda100\n",
+    "!pip install nnabla-ext-cuda114\n",
     "!git clone https://github.com/sony/nnabla-examples.git\n",
     "%run nnabla-examples/interactive-demos/colab_utils.py\n",
     "%cd nnabla-examples/image-classification/imagenet"

--- a/interactive-demos/out_of_core_training.ipynb
+++ b/interactive-demos/out_of_core_training.ipynb
@@ -60,7 +60,7 @@
    "outputs": [],
    "source": [
     "# install nnabla\n",
-    "!pip install nnabla-ext-cuda110\n",
+    "!pip install nnabla-ext-cuda114\n",
     "\n",
     "# clone nnabla-examples\n",
     "!git clone https://github.com/sony/nnabla-examples.git\n",

--- a/interactive-demos/prejudice_remover_regularizer.ipynb
+++ b/interactive-demos/prejudice_remover_regularizer.ipynb
@@ -57,7 +57,7 @@
     "# Preparation\n",
     "!git clone https://github.com/sony/nnabla-examples.git\n",
     "%cd nnabla-examples/responsible_ai/prejudice_remover_regularizer\n",
-    "!pip install nnabla-ext-cuda100\n",
+    "!pip install nnabla-ext-cuda114\n",
     "\n",
     "import cv2\n",
     "from google.colab.patches import cv2_imshow\n",

--- a/interactive-demos/prejudice_remover_regularizer_image.ipynb
+++ b/interactive-demos/prejudice_remover_regularizer_image.ipynb
@@ -52,7 +52,7 @@
     "# Preparation\n",
     "!git clone https://github.com/sony/nnabla-examples.git\n",
     "%cd nnabla-examples/responsible_ai/prejudice_remover_regularizer_images\n",
-    "!pip install nnabla-ext-cuda100\n",
+    "!pip install nnabla-ext-cuda114\n",
     "!pip install albumentations\n",
     "\n",
     "import cv2\n",

--- a/interactive-demos/psmnet.ipynb
+++ b/interactive-demos/psmnet.ipynb
@@ -31,7 +31,7 @@
       "cell_type": "code",
       "metadata": {},
       "source": [
-        "!pip install nnabla-ext-cuda100\n",
+        "!pip install nnabla-ext-cuda114\n",
         "!git clone https://github.com/sony/nnabla-examples.git\n",
         "%cd nnabla-examples/stereo-depth/PSMnet"
       ],

--- a/interactive-demos/quantization_tutorial.ipynb
+++ b/interactive-demos/quantization_tutorial.ipynb
@@ -52,7 +52,7 @@
    },
    "outputs": [],
    "source": [
-    "!pip install nnabla nnabla-ext-cuda110 nnabla-converter"
+    "!pip install nnabla nnabla-ext-cuda114 nnabla-converter"
    ]
   },
   {

--- a/interactive-demos/reject_option_based_classification_images.ipynb
+++ b/interactive-demos/reject_option_based_classification_images.ipynb
@@ -52,7 +52,7 @@
     "Preparation\n",
     "!git clone https://github.com/sony/nnabla-examples.git\n",
     "%cd nnabla-examples/responsible_ai/rejection_option_based_classification_images\n",
-    "!pip install nnabla-ext-cuda100\n",
+    "!pip install nnabla-ext-cuda114\n",
     "!pip install albumentations\n",
     "\n",
     "import cv2\n",

--- a/interactive-demos/sagan.ipynb
+++ b/interactive-demos/sagan.ipynb
@@ -26,7 +26,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install nnabla-ext-cuda100\n",
+    "!pip install nnabla-ext-cuda114\n",
     "!git clone https://github.com/sony/nnabla-examples.git\n",
     "%cd nnabla-examples/image-generation/sagan"
    ]

--- a/interactive-demos/shap.ipynb
+++ b/interactive-demos/shap.ipynb
@@ -57,7 +57,7 @@
         "id": "fCVUXPwnxm5Z"
       },
       "source": [
-        "!pip install nnabla-ext-cuda100\n",
+        "!pip install nnabla-ext-cuda114\n",
         "!git clone https://github.com/sony/nnabla-examples.git\n",
         "%cd nnabla-examples/responsible_ai/shap"
       ],

--- a/interactive-demos/slegan.ipynb
+++ b/interactive-demos/slegan.ipynb
@@ -24,7 +24,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install nnabla-ext-cuda100\n",
+    "!pip install nnabla-ext-cuda114\n",
     "!git clone https://github.com/sony/nnabla-examples.git\n",
     "%cd nnabla-examples/image-generation/slegan"
    ]

--- a/interactive-demos/stargan.ipynb
+++ b/interactive-demos/stargan.ipynb
@@ -35,7 +35,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install nnabla-ext-cuda100\n",
+    "!pip install nnabla-ext-cuda114\n",
     "!git clone https://github.com/sony/nnabla-examples.git\n",
     "%run nnabla-examples/interactive-demos/colab_utils.py\n",
     "%cd nnabla-examples/image-translation/stargan"

--- a/interactive-demos/stylegan2.ipynb
+++ b/interactive-demos/stylegan2.ipynb
@@ -25,7 +25,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install nnabla-ext-cuda100\n",
+    "!pip install nnabla-ext-cuda114\n",
     "!git clone https://github.com/sony/nnabla-examples.git\n",
     "%cd nnabla-examples/image-generation/stylegan2"
    ]

--- a/interactive-demos/tecogan.ipynb
+++ b/interactive-demos/tecogan.ipynb
@@ -30,7 +30,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install nnabla-ext-cuda100\n",
+    "!pip install nnabla-ext-cuda114\n",
     "!pip install ffmpeg\n",
     "!git clone https://github.com/sony/nnabla-examples.git\n",
     "%cd nnabla-examples/video-superresolution/tecogan"

--- a/interactive-demos/yolov2.ipynb
+++ b/interactive-demos/yolov2.ipynb
@@ -24,7 +24,7 @@
       "cell_type": "code",
       "metadata": {},
       "source": [
-        "!pip install nnabla-ext-cuda100\n",
+        "!pip install nnabla-ext-cuda114\n",
         "!git clone https://github.com/sony/nnabla-examples.git\n",
         "%run nnabla-examples/interactive-demos/colab_utils.py\n",
         "%cd nnabla-examples/object-detection/yolov2"

--- a/interactive-demos/zooming_slowmo.ipynb
+++ b/interactive-demos/zooming_slowmo.ipynb
@@ -24,7 +24,7 @@
       "cell_type": "code",
       "metadata": {},
       "source": [
-        "!pip install nnabla-ext-cuda100\r\n",
+        "!pip install nnabla-ext-cuda114\r\n",
         "!git clone https://github.com/sony/nnabla-examples.git\r\n",
         "%cd nnabla-examples/frame-interpolation/zooming-slow-mo"
       ],


### PR DESCRIPTION
Google Colab was upgraded: https://colab.research.google.com/notebooks/relnotes.ipynb#scrollTo=mNnf5izyVyF0+
It shows that cuda in colab has been upgraded to 11.2.

So, we will change to use nnabla-ext-cuda114, and it is compatible with current colab cuda environment.