### PR TITLE
Patch for directory traversal vulnerability

### DIFF
--- a/graph-neural-networks/GCN/utils.py
+++ b/graph-neural-networks/GCN/utils.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import sys
 import numpy as np
 import networkx as nx
 import pandas as pd
@@ -19,6 +20,9 @@ import os
 import tarfile
 from urllib.request import urlopen
 from sklearn.preprocessing import LabelEncoder
+
+sys.path.append("../../utils/")
+from neu.safe_extract import safe_extract
 
 CORA_URL = "https://linqs-data.soe.ucsc.edu/public/lbc/cora.tgz"
 
@@ -38,25 +42,7 @@ def download_cora(url=CORA_URL):
     if not os.path.exists('./cora'):
         print('Extracting cora dataset...')
         with tarfile.open('./cora.tgz', 'r') as f:
-            def is_within_directory(directory, target):
-
-                abs_directory = os.path.abspath(directory)
-                abs_target = os.path.abspath(target)
-
-                prefix = os.path.commonprefix([abs_directory, abs_target])
-
-                return prefix == abs_directory
-
-            def safe_extract(tar, path=".", members=None, *, numeric_owner=False):
-
-                for member in tar.getmembers():
-                    member_path = os.path.join(path, member.name)
-                    if not is_within_directory(path, member_path):
-                        raise Exception("Attempted Path Traversal in Tar File")
-
-                tar.extractall(path, members, numeric_owner=numeric_owner)
-
-            safe_extract(f, "./")
+            safe_extract(f, './')
     else:
         print('Cora dataset is already extracted.')
 

--- a/graph-neural-networks/GCN/utils.py
+++ b/graph-neural-networks/GCN/utils.py
@@ -39,24 +39,23 @@ def download_cora(url=CORA_URL):
         print('Extracting cora dataset...')
         with tarfile.open('./cora.tgz', 'r') as f:
             def is_within_directory(directory, target):
-                
+
                 abs_directory = os.path.abspath(directory)
                 abs_target = os.path.abspath(target)
-            
+
                 prefix = os.path.commonprefix([abs_directory, abs_target])
-                
+
                 return prefix == abs_directory
-            
+
             def safe_extract(tar, path=".", members=None, *, numeric_owner=False):
-            
+
                 for member in tar.getmembers():
                     member_path = os.path.join(path, member.name)
                     if not is_within_directory(path, member_path):
                         raise Exception("Attempted Path Traversal in Tar File")
-            
-                tar.extractall(path, members, numeric_owner=numeric_owner) 
-                
-            
+
+                tar.extractall(path, members, numeric_owner=numeric_owner)
+
             safe_extract(f, "./")
     else:
         print('Cora dataset is already extracted.')

--- a/graph-neural-networks/Graph U-Nets/utils.py
+++ b/graph-neural-networks/Graph U-Nets/utils.py
@@ -42,24 +42,23 @@ def download_cora(url=CORA_URL):
         print('Extracting cora dataset...')
         with tarfile.open('./cora.tgz', 'r') as f:
             def is_within_directory(directory, target):
-                
+
                 abs_directory = os.path.abspath(directory)
                 abs_target = os.path.abspath(target)
-            
+
                 prefix = os.path.commonprefix([abs_directory, abs_target])
-                
+
                 return prefix == abs_directory
-            
+
             def safe_extract(tar, path=".", members=None, *, numeric_owner=False):
-            
+
                 for member in tar.getmembers():
                     member_path = os.path.join(path, member.name)
                     if not is_within_directory(path, member_path):
                         raise Exception("Attempted Path Traversal in Tar File")
-            
-                tar.extractall(path, members, numeric_owner=numeric_owner) 
-                
-            
+
+                tar.extractall(path, members, numeric_owner=numeric_owner)
+
             safe_extract(f, "./")
     else:
         print('Cora dataset is already extracted.')

--- a/graph-neural-networks/Graph U-Nets/utils.py
+++ b/graph-neural-networks/Graph U-Nets/utils.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import sys
 import nnabla as nn
 import numpy as np
 import networkx as nx
@@ -21,6 +22,9 @@ import subprocess
 import tarfile
 from urllib.request import urlopen
 from sklearn.preprocessing import LabelEncoder
+
+sys.path.append("../../utils/")
+from neu.safe_extract import safe_extract
 
 
 CORA_URL = "https://linqs-data.soe.ucsc.edu/public/lbc/cora.tgz"
@@ -41,25 +45,7 @@ def download_cora(url=CORA_URL):
     if not os.path.exists('./cora'):
         print('Extracting cora dataset...')
         with tarfile.open('./cora.tgz', 'r') as f:
-            def is_within_directory(directory, target):
-
-                abs_directory = os.path.abspath(directory)
-                abs_target = os.path.abspath(target)
-
-                prefix = os.path.commonprefix([abs_directory, abs_target])
-
-                return prefix == abs_directory
-
-            def safe_extract(tar, path=".", members=None, *, numeric_owner=False):
-
-                for member in tar.getmembers():
-                    member_path = os.path.join(path, member.name)
-                    if not is_within_directory(path, member_path):
-                        raise Exception("Attempted Path Traversal in Tar File")
-
-                tar.extractall(path, members, numeric_owner=numeric_owner)
-
-            safe_extract(f, "./")
+            safe_extract(f, './')
     else:
         print('Cora dataset is already extracted.')
 

--- a/image-generation/sagan/create_val_dir.py
+++ b/image-generation/sagan/create_val_dir.py
@@ -32,25 +32,25 @@ dst_dir = args.outdir
 
 with tarfile.open(source_tar_file) as tf:
     v_tmp_dir = dst_dir + '/' + 'tmpdir'
+
     def is_within_directory(directory, target):
-        
+
         abs_directory = os.path.abspath(directory)
         abs_target = os.path.abspath(target)
-    
+
         prefix = os.path.commonprefix([abs_directory, abs_target])
-        
+
         return prefix == abs_directory
-    
+
     def safe_extract(tar, path=".", members=None, *, numeric_owner=False):
-    
+
         for member in tar.getmembers():
             member_path = os.path.join(path, member.name)
             if not is_within_directory(path, member_path):
                 raise Exception("Attempted Path Traversal in Tar File")
-    
-        tar.extractall(path, members, numeric_owner=numeric_owner) 
-        
-    
+
+        tar.extractall(path, members, numeric_owner=numeric_owner)
+
     safe_extract(tf, v_tmp_dir)
 with open(os.path.join(os.path.dirname(__file__), "category_list.txt")) as f:
     categories = f.readlines()

--- a/image-generation/sagan/create_val_dir.py
+++ b/image-generation/sagan/create_val_dir.py
@@ -15,10 +15,14 @@
 
 
 import os
+import sys
 import tarfile
 import argparse
 import tqdm
 import shutil
+
+sys.path.append("../../utils/")
+from neu.safe_extract import safe_extract
 
 parser = argparse.ArgumentParser()
 parser.add_argument(
@@ -32,25 +36,6 @@ dst_dir = args.outdir
 
 with tarfile.open(source_tar_file) as tf:
     v_tmp_dir = dst_dir + '/' + 'tmpdir'
-
-    def is_within_directory(directory, target):
-
-        abs_directory = os.path.abspath(directory)
-        abs_target = os.path.abspath(target)
-
-        prefix = os.path.commonprefix([abs_directory, abs_target])
-
-        return prefix == abs_directory
-
-    def safe_extract(tar, path=".", members=None, *, numeric_owner=False):
-
-        for member in tar.getmembers():
-            member_path = os.path.join(path, member.name)
-            if not is_within_directory(path, member_path):
-                raise Exception("Attempted Path Traversal in Tar File")
-
-        tar.extractall(path, members, numeric_owner=numeric_owner)
-
     safe_extract(tf, v_tmp_dir)
 with open(os.path.join(os.path.dirname(__file__), "category_list.txt")) as f:
     categories = f.readlines()

--- a/responsible_ai/data_cleansing/datasets/create_stl10_csv.py
+++ b/responsible_ai/data_cleansing/datasets/create_stl10_csv.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import sys
 import os
 import numpy as np
 from contextlib import contextmanager
@@ -26,6 +27,9 @@ from nnabla.utils.data_source_loader import download
 import tarfile
 import argparse
 from .utils import split_data_into_train_val, save_list_to_csv, get_filename_to_download, ensure_dir
+
+sys.path.append("../../utils/")
+from neu.safe_extract import safe_extract
 
 
 class STL10DataSource(DataSource):
@@ -46,24 +50,6 @@ class STL10DataSource(DataSource):
         print(r.name)
         binary_dir = os.path.join(output_dir, "stl10_binary")
         with tarfile.open(fileobj=r, mode="r:gz") as tar:
-            def is_within_directory(directory, target):
-
-                abs_directory = os.path.abspath(directory)
-                abs_target = os.path.abspath(target)
-
-                prefix = os.path.commonprefix([abs_directory, abs_target])
-
-                return prefix == abs_directory
-
-            def safe_extract(tar, path=".", members=None, *, numeric_owner=False):
-
-                for member in tar.getmembers():
-                    member_path = os.path.join(path, member.name)
-                    if not is_within_directory(path, member_path):
-                        raise Exception("Attempted Path Traversal in Tar File")
-
-                tar.extractall(path, members, numeric_owner=numeric_owner)
-
             safe_extract(tar, path=output_dir)
 
         for member in os.listdir(binary_dir):

--- a/responsible_ai/data_cleansing/datasets/create_stl10_csv.py
+++ b/responsible_ai/data_cleansing/datasets/create_stl10_csv.py
@@ -47,24 +47,23 @@ class STL10DataSource(DataSource):
         binary_dir = os.path.join(output_dir, "stl10_binary")
         with tarfile.open(fileobj=r, mode="r:gz") as tar:
             def is_within_directory(directory, target):
-                
+
                 abs_directory = os.path.abspath(directory)
                 abs_target = os.path.abspath(target)
-            
+
                 prefix = os.path.commonprefix([abs_directory, abs_target])
-                
+
                 return prefix == abs_directory
-            
+
             def safe_extract(tar, path=".", members=None, *, numeric_owner=False):
-            
+
                 for member in tar.getmembers():
                     member_path = os.path.join(path, member.name)
                     if not is_within_directory(path, member_path):
                         raise Exception("Attempted Path Traversal in Tar File")
-            
-                tar.extractall(path, members, numeric_owner=numeric_owner) 
-                
-            
+
+                tar.extractall(path, members, numeric_owner=numeric_owner)
+
             safe_extract(tar, path=output_dir)
 
         for member in os.listdir(binary_dir):

--- a/utils/neu/safe_extract.py
+++ b/utils/neu/safe_extract.py
@@ -1,0 +1,32 @@
+# Copyright 2022 Sony Group Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import tarfile
+
+
+def safe_extract(tar, path=".", members=None, *, numeric_owner=False):
+    def is_within_directory(directory, target):
+        abs_directory = os.path.abspath(directory)
+        abs_target = os.path.abspath(target)
+
+        prefix = os.path.commonprefix([abs_directory, abs_target])
+        return prefix == abs_directory
+
+    for member in tar.getmembers():
+        member_path = os.path.join(path, member.name)
+        if not is_within_directory(path, member_path):
+            raise Exception("Attempted Path Traversal in Tar File")
+
+    tar.extractall(path, members, numeric_owner=numeric_owner)


### PR DESCRIPTION
Python has traversal vulnerabilities in tar.extract() / tar.extractall(), this PR checks and extracted safely.

The original commit is contributed from Trellix, and I applied auto-format and handled it as common function.
Original PR: https://github.com/sony/nnabla-examples/pull/358
