### PR TITLE
Fix the output data order of Centernet

### DIFF
--- a/object-detection/centernet/README.md
+++ b/object-detection/centernet/README.md
@@ -207,10 +207,10 @@ You may want to change the memory layout of trained parameters from NHWC (traine
 The following command converts a parameter file to a desired configuration.
 
 ```bash
-python convert_parameter_format.py {input h5 file} {output h5 file} -m {layout either nchw or nhwc} -3
+python src/convert_parameter_format.py {input h5 file} {output h5 file} -m {layout either nchw or nhwc} -3
 ```
 
-See options with `python convert_parameter_format.py -h`.
+See options with `python src/convert_parameter_format.py -h`.
 
 ## Development/Extensions
 

--- a/object-detection/centernet/README.md
+++ b/object-detection/centernet/README.md
@@ -200,6 +200,18 @@ python src/save_nnp.py ctdet --config_file cfg/dlav0_34_coco_fp.yaml
 
 Please run `python src/save_nnp.py -h` to see which network is supported.
 
+## Memory layout conversion
+
+You may want to change the memory layout of trained parameters from NHWC (trained with `channel_last=True`) to NCHW and vice versa, for fine-tuning on differnt tasks for example. You may also want to the remove the 4-th channel in the first convolution which was padded to RGB input during training for speed advantage.
+
+The following command converts a parameter file to a desired configuration.
+
+```bash
+python convert_parameter_format.py {input h5 file} {output h5 file} -m {layout either nchw or nhwc} -3
+```
+
+See options with `python convert_parameter_format.py -h`.
+
 ## Development/Extensions
 
 ### Adding new models

--- a/object-detection/centernet/README.md
+++ b/object-detection/centernet/README.md
@@ -84,7 +84,7 @@ done
 
 ### PASCAL VOC
 
-For PASCAL VOC, see the example script located on ```src/lib/tools/get_pascal_voc.sh```. It downloads the dataset, the annotations already in COCO format and merges them.
+For PASCAL VOC, see the example script located on ```src/tools/get_pascal_voc.sh```. It downloads the dataset, the annotations already in COCO format and merges them.
 
 ## Training
 

--- a/object-detection/centernet/cfg/dlav0_34_coco_mp.yaml
+++ b/object-detection/centernet/cfg/dlav0_34_coco_mp.yaml
@@ -33,4 +33,4 @@ mixed_precision:
   mixed_precision: true
   channel_last: true
   loss_scaling: 4.0
-  use_dynamic_loss_scaling: false
+  use_dynamic_loss_scaling: true

--- a/object-detection/centernet/cfg/dlav0_34_pascal_mp.yaml
+++ b/object-detection/centernet/cfg/dlav0_34_pascal_mp.yaml
@@ -33,4 +33,4 @@ mixed_precision:
   mixed_precision: true
   channel_last: true
   loss_scaling: 4.0
-  use_dynamic_loss_scaling: false
+  use_dynamic_loss_scaling: true

--- a/object-detection/centernet/cfg/resnet_18_coco_mp.yaml
+++ b/object-detection/centernet/cfg/resnet_18_coco_mp.yaml
@@ -33,4 +33,4 @@ mixed_precision:
   mixed_precision: true
   channel_last: true
   loss_scaling: 4.0
-  use_dynamic_loss_scaling: false
+  use_dynamic_loss_scaling: true

--- a/object-detection/centernet/cfg/resnet_18_pascal_mp.yaml
+++ b/object-detection/centernet/cfg/resnet_18_pascal_mp.yaml
@@ -33,4 +33,4 @@ mixed_precision:
   mixed_precision: true
   channel_last: true
   loss_scaling: 4.0
-  use_dynamic_loss_scaling: false
+  use_dynamic_loss_scaling: true

--- a/object-detection/centernet/src/convert_parameter_format.py
+++ b/object-detection/centernet/src/convert_parameter_format.py
@@ -31,7 +31,7 @@ def get_args():
         "output", help='Path to an output h5 paramter file which will be created.')
     parser.add_argument('--affine-to-conv', '-a', action='store_true', default=False,
                         help='convert affine layer to 1x1 convolution')
-    parser.add_argument('--memory-layout', '-m',
+    parser.add_argument('--memory-layout', '-m', choices=['nhwc', 'nchw'],
                         help='Convert weight to "NHWC" or "NCHW".', default=None)
     parser.add_argument('--force-4-channels', '-4', action='store_true', default=False,
                         help='Add padded 4-th channel in first layer convolution.')

--- a/object-detection/centernet/src/convert_parameter_format.py
+++ b/object-detection/centernet/src/convert_parameter_format.py
@@ -58,8 +58,6 @@ def convert_memory_layout(params, layout):
     for key in params.keys():
         if key.endswith('conv/b'):
             continue
-        if key.endswith('deconv/W'):
-            continue
         param = params[key]
         array = param.d
         if layout == 'nhwc':

--- a/object-detection/centernet/src/lib/detectors/ctdet.py
+++ b/object-detection/centernet/src/lib/detectors/ctdet.py
@@ -46,10 +46,10 @@ class CtdetDetector(BaseDetector):
         """
         inputs = nn.Variable.from_numpy_array(images)
         outputs = self.model(inputs)
-        hm = outputs[0]
+        hm = outputs['hm']
         hm = F.sigmoid(hm)
-        wh = outputs[1]
-        reg = outputs[2]
+        wh = outputs['wh']
+        reg = outputs['reg']
         if self.opt.channel_last:
             hm = F.transpose(hm, (0, 3, 1, 2))
             wh = F.transpose(wh, (0, 3, 1, 2))
@@ -102,7 +102,7 @@ class CtdetDetector(BaseDetector):
     def debug(self, debugger, images, dets, output, scale=1):
         detection = dets.copy()
         detection[:, :, :4] *= self.opt.down_ratio
-        hm = output[0]
+        hm = output['hm']
         hm = F.sigmoid(hm)
         if self.opt.channel_last:
             hm = F.transpose(hm, (0, 3, 1, 2))

--- a/object-detection/centernet/src/lib/models/networks/centernet_dlav0.py
+++ b/object-detection/centernet/src/lib/models/networks/centernet_dlav0.py
@@ -90,8 +90,8 @@ class PoseDLA(object):
         features = self.backbone_model(
             input_variable, test=not self.training, channel_last=self.channel_last)
 
-        output = []
-        for head in sorted(self.heads):
+        output = dict()
+        for head in self.heads:
             num_output = self.heads[head]
             if self.head_conv > 0:
                 with nn.parameter_scope(head + "_conv1"):
@@ -138,7 +138,7 @@ class PoseDLA(object):
                         with_bias=True,
                         channel_last=self.channel_last,
                     )
-            output.append(out)
+            output.update({head: out})
         return output
 
 

--- a/object-detection/centernet/src/lib/models/networks/centernet_resnet.py
+++ b/object-detection/centernet/src/lib/models/networks/centernet_resnet.py
@@ -192,8 +192,8 @@ class PoseResNet(object):
                 )
             )
 
-        output = []
-        for head in sorted(self.heads):
+        output = dict()
+        for head in self.heads:
             num_output = self.heads[head]
             rng = np.random.RandomState(313)
             b_init_param = -2.19 if head == 'hm' else 0.0
@@ -241,7 +241,7 @@ class PoseResNet(object):
                         b_init=ConstantInitializer(b_init_param),
                         channel_last=self.channel_last,
                     )
-            output.append(out)
+            output.update({head: out})
         return output
 
 

--- a/object-detection/centernet/src/lib/opts.py
+++ b/object-detection/centernet/src/lib/opts.py
@@ -232,9 +232,7 @@ class opts(object):
         opt.output_res = max(opt.output_h, opt.output_w)
         if opt.task == 'ctdet':
             # assert opt.dataset in ['pascal', 'coco']
-            opt.heads = {'hm': opt.num_classes,
-                         'wh': 2}  # if not opt.cat_spec_wh else 2 * opt.num_classes}
-            opt.heads.update({'reg': 2})
+            opt.heads = {'hm': opt.num_classes, 'reg': 2, 'wh': 2}
             opt.dataset_info = {'max_objs': dataset.max_objs}
         else:
             assert 0, 'task {} not defined!'.format(opt.task)

--- a/object-detection/centernet/src/lib/trains/ctdet.py
+++ b/object-detection/centernet/src/lib/trains/ctdet.py
@@ -237,7 +237,10 @@ class Trainer(object):
     def compute_loss(self, data):
         # Performs forward pass.
         self._img.d, self._hm.d, self._inds.d, self._wh.d, self._reg.d, self._reg_mask.d, _ = data
-        pred_hm, pred_wh, pred_reg = self.model(self._img)
+        pred_dict = self.model(self._img)
+        pred_hm = pred_dict['hm']
+        pred_wh = pred_dict['wh']
+        pred_reg = pred_dict['reg']
         loss = self.loss_func(
             pred_hm, pred_wh, pred_reg, self._hm, self._inds,
             self._wh, self._reg, self._reg_mask, self.comm,

--- a/object-detection/centernet/src/lib/utils/debugger.py
+++ b/object-detection/centernet/src/lib/utils/debugger.py
@@ -596,11 +596,7 @@ color_list = color_list.reshape((-1, 3)) * 255
 def save_nnp(opt, model, extension='nnp'):
 
     input_variable = nn.Variable([1, 3, opt.input_h, opt.input_w])
-    output_list = model(input_variable)
-
-    pred_dict = dict()
-    for i, key in enumerate(opt.heads):
-        pred_dict[key] = output_list[i]
+    pred_dict = model(input_variable)
 
     runtime_contents = {
         'networks': [{'name': 'runtime', 'batch_size': 1, 'outputs': pred_dict, 'names': {'x': input_variable}}],

--- a/object-detection/centernet/src/save_graph.py
+++ b/object-detection/centernet/src/save_graph.py
@@ -22,6 +22,7 @@ import _init_paths
 import os
 
 import nnabla as nn
+import nnabla.functions as F
 import nnabla.experimental.viewers as V
 from models.model import create_model, load_nnp_model
 from opts import opts
@@ -29,7 +30,8 @@ from opts import opts
 
 def save_network_graph(filename, pred_dict, format='svg'):
     graph = V.SimpleGraph(format=format, verbose=True)
-    graph.save(pred_dict['hm'], filename)
+    output_list = pred_dict.values()
+    graph.save(F.sink(*output_list), filename)
     nn.logger.info("Output network graph {}".format(filename))
 
 
@@ -43,13 +45,9 @@ def main(opt):
         model = create_model(opt.arch, opt.heads, opt.head_conv, opt.num_layers,
                              training=False, channel_last=opt.channel_last)
         input_variable = nn.Variable([1, 3, 512, 512])
-        output_list = model(input_variable)
+        pred_dict = model(input_variable)
         filename = os.path.join(
             opt.save_dir, '{}_{}_graph'.format(opt.arch, opt.num_layers))
-
-    pred_dict = dict()
-    for i, key in enumerate(opt.heads):
-        pred_dict[key] = output_list[i]
 
     save_network_graph(filename, pred_dict)
 

--- a/object-detection/centernet/src/tools/get_pascal_voc.sh
+++ b/object-detection/centernet/src/tools/get_pascal_voc.sh
@@ -1,0 +1,59 @@
+# Copyright 2021 Sony Corporation.
+# Copyright 2021 Sony Group Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# --------------------------------------------------------
+# Reference: https://github.com/xingyizhou/CenterNet
+# --------------------------------------------------------
+
+VOC_ROOT=voc/
+ORIG_DIR=$(pwd)
+
+mkdir $VOC_ROOT
+cd $VOC_ROOT
+
+# Download Pascal VOC image tar files.
+wget http://host.robots.ox.ac.uk/pascal/VOC/voc2007/VOCtrainval_06-Nov-2007.tar
+wget http://host.robots.ox.ac.uk/pascal/VOC/voc2007/VOCtest_06-Nov-2007.tar
+wget http://host.robots.ox.ac.uk/pascal/VOC/voc2007/VOCdevkit_08-Jun-2007.tar
+wget http://host.robots.ox.ac.uk/pascal/VOC/voc2012/VOCtrainval_11-May-2012.tar
+wget http://host.robots.ox.ac.uk/pascal/VOC/voc2012/VOCdevkit_18-May-2011.tar
+
+# Extract tar files and remove them.
+tar xvf VOCtrainval_06-Nov-2007.tar
+tar xvf VOCtest_06-Nov-2007.tar
+tar xvf VOCdevkit_08-Jun-2007.tar
+tar xvf VOCtrainval_11-May-2012.tar
+tar xvf VOCdevkit_18-May-2011.tar
+rm VOCtrainval_06-Nov-2007.tar
+rm VOCtest_06-Nov-2007.tar
+rm VOCdevkit_08-Jun-2007.tar
+rm VOCtrainval_11-May-2012.tar
+rm VOCdevkit_18-May-2011.tar
+
+# Move images to $VOC_ROOT/images/
+mkdir images
+cp VOCdevkit/VOC2007/JPEGImages/* images/
+cp VOCdevkit/VOC2012/JPEGImages/* images/
+
+# Donwload PASCAL VOC annotations in COCO format and move them to $VOC_ROOT/annotations.
+# Or, you also convert them yourself, for example in a similar way with https://github.com/soumenpramanik/Convert-Pascal-VOC-to-COCO/blob/master/convertVOC2COCO.py
+wget https://s3.amazonaws.com/images.cocodataset.org/external/external_PASCAL_VOC.zip
+unzip external_PASCAL_VOC.zip
+rm external_PASCAL_VOC.zip
+mv PASCAL_VOC annotations/
+
+
+# Merge all Pascal VOC annotationos from train-val of 2007 & 2012.
+cd $ORIG_DIR
+python src/tools/merge_pascal_json.py -a $VOC_ROOT/annotations

--- a/object-detection/centernet/src/tools/merge_pascal_json.py
+++ b/object-detection/centernet/src/tools/merge_pascal_json.py
@@ -1,0 +1,66 @@
+# Copyright 2021 Sony Corporation.
+# Copyright 2021 Sony Group Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# --------------------------------------------------------
+# Reference: https://github.com/xingyizhou/CenterNet
+# --------------------------------------------------------
+
+def get_args():
+    import argparse
+    p = argparse.ArgumentParser()
+    p.add_argument('--annot-path', '-a', type=str, default='voc/annotations/',
+                   help='A folder where annotation JSON files are located.')
+    p.add_argument('--out-path', '-o', type=str, default=None,
+                   help='A folder where a merged output JSON file will be generated. The default will be the same location as --annot-path.')
+    args = p.parse_args()
+    return args
+
+
+def main():
+    import json
+    from os.path import join
+    args = get_args()
+    ANNOT_PATH = args.annot_path
+    if args.out_path is None:
+        args.out_path = args.annot_path
+    OUT_PATH = args.out_path
+    INPUT_FILES = ['pascal_train2012.json', 'pascal_val2012.json',
+                   'pascal_train2007.json', 'pascal_val2007.json']
+    OUTPUT_FILE = 'pascal_trainval0712.json'
+    KEYS = ['images', 'type', 'annotations', 'categories']
+    MERGE_KEYS = ['images', 'annotations']
+
+    out = {}
+    tot_anns = 0
+    for i, file_name in enumerate(INPUT_FILES):
+        data = json.load(open(join(ANNOT_PATH, file_name), 'r'))
+        print('keys', data.keys())
+        if i == 0:
+            for key in KEYS:
+                out[key] = data[key]
+                print(file_name, key, len(data[key]))
+        else:
+            out['images'] += data['images']
+            for j in range(len(data['annotations'])):
+                data['annotations'][j]['id'] += tot_anns
+            out['annotations'] += data['annotations']
+            print(file_name, 'images', len(data['images']))
+            print(file_name, 'annotations', len(data['annotations']))
+        tot_anns = len(out['annotations'])
+    print('tot', len(out['annotations']))
+    json.dump(out, open(join(OUT_PATH, OUTPUT_FILE), 'w'))
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
### Bug fixes

* Currently the prediction outputs of the object detection task are stored in [hm, reg, wh] order but all the codes treat the outputs as [hm, wh, reg] order. Fix the bug so all codes can access the correct data. Also, to prevent indexing errors, use `dict` to store the prediction outputs instead of using `list`.
* Fix the bug in `resnet_18_coco_mp.h5` and `resnet_18_pascal_mp.h5`: the weights of the deconvolution layers are not saved in `NHWC` format. Instead, they are saved in `NCHW` format and will cause shape inconsistency.
* Enable dynamic loss scaling for mixed-precision training.