### PR TITLE
numpy don't support long type from 1.26.3

### DIFF
--- a/vision-and-language/clip/clip/clip.py
+++ b/vision-and-language/clip/clip/clip.py
@@ -62,7 +62,7 @@ def load(name, jit=False, download_root=None):
     Parameters
     ----------
     name : str
-        A model name or the path to the checkopoint 
+        A model name or the path to the checkopoint
     jit : bool, optional
         [description], by default False
     download_root : [type], optional
@@ -161,7 +161,7 @@ def tokenize(texts: Union[str, List[str]], context_length: int = 77, truncate: b
     eot_token = _tokenizer.encoder["<|endoftext|>"]
     all_tokens = [[sot_token] +
                   _tokenizer.encode(text) + [eot_token] for text in texts]
-    result = np.zeros((len(all_tokens), context_length), dtype=np.long)
+    result = np.zeros((len(all_tokens), context_length), dtype=np.longlong)
 
     for i, tokens in enumerate(all_tokens):
         if len(tokens) > context_length:

--- a/vision-and-language/cliport/nnabla_cliport/clip/clip.py
+++ b/vision-and-language/cliport/nnabla_cliport/clip/clip.py
@@ -59,7 +59,7 @@ def load(name, jit=False, download_root=None):
     Parameters
     ----------
     name : str
-        A model name or the path to the checkopoint 
+        A model name or the path to the checkopoint
     jit : bool, optional
         [description], by default False
     download_root : [type], optional
@@ -132,7 +132,7 @@ def tokenize(texts: Union[str, List[str]], context_length: int = 77, truncate: b
     eot_token = _tokenizer.encoder["<|endoftext|>"]
     all_tokens = [[sot_token] +
                   _tokenizer.encode(text) + [eot_token] for text in texts]
-    result = np.zeros((len(all_tokens), context_length), dtype=np.long)
+    result = np.zeros((len(all_tokens), context_length), dtype=np.longlong)
 
     for i, tokens in enumerate(all_tokens):
         if len(tokens) > context_length:


### PR DESCRIPTION
The CLIP used `np.long`, but it's already deprecated for a long time.
This PR just updates the dtype.